### PR TITLE
Set Vite base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 export default defineConfig({
+  base: "/integral-counselor-website/",
   plugins: [
     react(),
     runtimeErrorOverlay(),


### PR DESCRIPTION
## Summary
- set the Vite build base to `/integral-counselor-website/` so GitHub Pages serves asset URLs correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d962d21498833285c41d1c3d1c25b6