### PR TITLE
Guard GitHub Pages base path configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,39 +3,55 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
-export default defineConfig({
-  base: "/integral-counselor-website/",
-  plugins: [
-    react(),
-    runtimeErrorOverlay(),
-    ...(process.env.NODE_ENV !== "production" &&
-    process.env.REPL_ID !== undefined
-      ? [
-          await import("@replit/vite-plugin-cartographer").then((m) =>
-            m.cartographer(),
-          ),
-          await import("@replit/vite-plugin-dev-banner").then((m) =>
-            m.devBanner(),
-          ),
-        ]
-      : []),
-  ],
-  resolve: {
-    alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+const githubPagesBase = "/integral-counselor-website/";
+
+const shouldUseGitHubPagesBase = () => {
+  if (process.env.DEPLOY_TARGET === "github-pages") {
+    return true;
+  }
+
+  if (process.env.VITE_DEPLOY_TARGET === "github-pages") {
+    return true;
+  }
+
+  return process.env.GITHUB_PAGES === "true";
+};
+
+export default defineConfig(async () => {
+  const plugins = [react(), runtimeErrorOverlay()];
+
+  const shouldLoadReplitPlugins =
+    process.env.NODE_ENV !== "production" && process.env.REPL_ID !== undefined;
+
+  if (shouldLoadReplitPlugins) {
+    const [{ cartographer }, { devBanner }] = await Promise.all([
+      import("@replit/vite-plugin-cartographer"),
+      import("@replit/vite-plugin-dev-banner"),
+    ]);
+
+    plugins.push(cartographer(), devBanner());
+  }
+
+  return {
+    base: shouldUseGitHubPagesBase() ? githubPagesBase : "/",
+    plugins,
+    resolve: {
+      alias: {
+        "@": path.resolve(import.meta.dirname, "client", "src"),
+        "@shared": path.resolve(import.meta.dirname, "shared"),
+        "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      },
     },
-  },
-  root: path.resolve(import.meta.dirname, "client"),
-  build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
-    emptyOutDir: true,
-  },
-  server: {
-    fs: {
-      strict: true,
-      deny: ["**/.*"],
+    root: path.resolve(import.meta.dirname, "client"),
+    build: {
+      outDir: path.resolve(import.meta.dirname, "dist/public"),
+      emptyOutDir: true,
     },
-  },
+    server: {
+      fs: {
+        strict: true,
+        deny: ["**/.*"],
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- configure the Vite base path dynamically so GitHub Pages builds keep their prefix without breaking other deployments
- defer loading Replit-specific plugins until needed to preserve async imports within the config

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eb681125608332a354cb25855b842f