### PR TITLE
Use informal Hungarian copy

### DIFF
--- a/client/src/i18n/locales/hu/appointment.json
+++ b/client/src/i18n/locales/hu/appointment.json
@@ -1,20 +1,20 @@
 {
   "title": "Konzultáció kérése",
-  "subtitle": "Küldje el időpontkérését; 24 órán belül válaszolok.",
+  "subtitle": "Küldd el az időpontkérésedet; 24 órán belül válaszolok.",
   "form": {
     "title": "Az időpontkérés adatai",
     "name": "Teljes név",
-    "name_placeholder": "Adja meg a teljes nevét",
+    "name_placeholder": "Add meg a teljes neved",
     "email": "E‑mail cím",
     "email_placeholder": "nev@example.com",
     "phone": "Telefonszám",
     "phone_placeholder": "+36 30 123 4567",
     "service": "Szolgáltatás",
-    "service_placeholder": "Válasszon szolgáltatást",
+    "service_placeholder": "Válassz szolgáltatást",
     "date": "Előnyben részesített dátum",
-    "date_placeholder": "Válasszon dátumot",
+    "date_placeholder": "Válassz dátumot",
     "time": "Előnyben részesített időpont",
-    "time_placeholder": "Válasszon időpontot",
+    "time_placeholder": "Válassz időpontot",
     "message": "További információ",
     "message_placeholder": "Amit érdemes tudnom előre...",
     "required": "kötelező",
@@ -30,15 +30,15 @@
   },
   "error": {
     "title": "Az időpontkérés nem lett elküldve",
-    "description": "Nem sikerült elküldeni a kérést. A megadott adatok megmaradtak, így újra próbálhatja, vagy közvetlenül kapcsolatba léphet velem.",
+    "description": "Nem sikerült elküldeni a kérést. A megadott adatok megmaradtak, így újra próbálhatod, vagy közvetlenül kapcsolatba léphetsz velem.",
     "email_action": "E-mail küldése ide: {{email}}"
   },
   "validation": {
     "name_required": "A név megadása kötelező.",
     "name_too_long": "A név legfeljebb 100 karakter lehet.",
-    "email_invalid": "Adjon meg egy érvényes e-mail címet.",
-    "date_required": "Válasszon egy dátumot.",
-    "time_required": "Válasszon egy időpontot."
+    "email_invalid": "Adj meg egy érvényes e-mail címet.",
+    "date_required": "Válassz egy dátumot.",
+    "time_required": "Válassz egy időpontot."
   },
-  "disclaimer": "A szolgáltatás nem orvosi vagy pszichiátriai ellátás. Sürgős helyzetben hívja a 112‑t."
+  "disclaimer": "A szolgáltatás nem orvosi vagy pszichiátriai ellátás. Sürgős helyzetben hívd a 112‑t."
 }

--- a/client/src/i18n/locales/hu/contact.json
+++ b/client/src/i18n/locales/hu/contact.json
@@ -1,10 +1,10 @@
 {
   "title": "Kapcsolatfelvétel",
-  "subtitle": "Írjon üzenetet vagy kérjen konzultációt.",
+  "subtitle": "Írj üzenetet vagy kérj konzultációt.",
   "form": {
     "title": "Kapcsolatfelvételi űrlap",
     "name": "Teljes név",
-    "name_placeholder": "Adja meg a teljes nevét",
+    "name_placeholder": "Add meg a teljes neved",
     "email": "E‑mail cím",
     "email_placeholder": "nev@example.com",
     "phone": "Telefonszám",
@@ -12,9 +12,9 @@
     "subject": "Tárgy",
     "subject_placeholder": "Miben segíthetek?",
     "contact_method": "Előnyben részesített kapcsolatfelvételi mód",
-    "contact_method_placeholder": "Hogyan szeretné, hogy kapcsolatba lépjek?",
+    "contact_method_placeholder": "Hogyan szeretnéd, hogy kapcsolatba lépjek?",
     "message": "Üzenet",
-    "message_placeholder": "Ossza meg röviden a témát vagy kérdéseit...",
+    "message_placeholder": "Oszd meg röviden a témát vagy a kérdéseidet...",
     "required": "kötelező",
     "submit": "Üzenet küldése",
     "sending": "Küldés..."
@@ -25,13 +25,13 @@
   },
   "error": {
     "title": "Az üzenet nem lett elküldve",
-    "description": "Nem sikerült elküldeni az üzenetet. A megadott adatok megmaradtak, így újra próbálhatja, vagy közvetlenül kapcsolatba léphet velem.",
+    "description": "Nem sikerült elküldeni az üzenetet. A megadott adatok megmaradtak, így újra próbálhatod, vagy közvetlenül kapcsolatba léphetsz velem.",
     "email_action": "E-mail küldése ide: {{email}}"
   },
   "validation": {
     "name_required": "A név megadása kötelező.",
     "name_too_long": "A név legfeljebb 100 karakter lehet.",
-    "email_invalid": "Adjon meg egy érvényes e-mail címet.",
+    "email_invalid": "Adj meg egy érvényes e-mail címet.",
     "message_required": "Az üzenet megadása kötelező.",
     "message_too_long": "Az üzenet legfeljebb 2000 karakter lehet."
   },
@@ -55,10 +55,10 @@
     "response_time": "Válasz általában 24 órán belül"
   },
   "emergency": {
-    "title": "Sürgős segítségre van szüksége?",
+    "title": "Sürgős segítségre van szükséged?",
     "description": "Itt nem nyújtunk sürgősségi ellátást. Sürgős helyzetben:",
     "crisis_hotline": "Lelki elsősegély: 116‑123 (0–24)",
     "emergency_services": "Sürgősségi hívószám: 112",
-    "crisis_text": "Ha nem Magyarországon tartózkodik, hívja a helyi segélyhívót."
+    "crisis_text": "Ha nem Magyarországon tartózkodsz, hívd a helyi segélyhívót."
   }
 }

--- a/client/src/i18n/locales/hu/footer.json
+++ b/client/src/i18n/locales/hu/footer.json
@@ -12,6 +12,6 @@
   "email": "karacsony.barni@gmail.com",
   "address": "Budapest\nMagyarország",
   "terms": "Felhasználási feltételek",
-  "emergency": "Sürgős helyzetben hívja a 112‑t vagy a 116‑123-at (lelki elsősegély).",
+  "emergency": "Sürgős helyzetben hívd a 112‑t vagy a 116‑123-at (lelki elsősegély).",
   "copyright": "© {{year}} Karácsony Barna. Minden jog fenntartva."
 }

--- a/client/src/i18n/locales/hu/home.json
+++ b/client/src/i18n/locales/hu/home.json
@@ -37,7 +37,7 @@
     "title": "Hogyan működik",
     "step1": {
       "title": "Kapcsolatfelvétel",
-      "description": "Írjon az űrlapon vagy e‑mailben."
+      "description": "Írj az űrlapon vagy e‑mailben."
     },
     "step2": {
       "title": "Ismerkedő beszélgetés",

--- a/client/src/i18n/locales/hu/legal.json
+++ b/client/src/i18n/locales/hu/legal.json
@@ -25,7 +25,7 @@
         "title": "Ülések és lemondás",
         "items": [
           "Egy ülés hossza 55 perc, hacsak másban nem állapodunk meg.",
-          "Kérjük, legalább 24 órával előre mondd le vagy módosítsd az időpontot; késői lemondás esetén a találkozó megtartottnak minősülhet.",
+          "Kérlek, legalább 24 órával előre mondd le vagy módosítsd az időpontot; késői lemondás esetén a találkozó megtartottnak minősülhet.",
           "Többszöri meg nem jelenés a jövőbeni foglalások felfüggesztését eredményezheti."
         ]
       },


### PR DESCRIPTION
## Összefoglalás

- A magyar főoldal, kapcsolatfelvételi és időpontkérő űrlap magázódó szövegeit tegeződő formára cseréli.
- Egységesíti a validációs, sikertelen beküldési és sürgősségi visszajelzések hangnemét.
- Javítja a lábléc, a folyamatleírás és a szolgáltatási feltételek vegyes hangnemű mondatait.

## Miért

A magyar felület több helyen keverte a magázó és tegező megszólítást, miközben az oldal többi része már tegeződött. A változtatás következetes, természetes felhasználói hangnemet biztosít.

## Ellenőrzés

- `npm run check`
- `npm run build`
- az összes magyar lokalizációs JSON szintaktikai ellenőrzése
- célzott keresés fennmaradó magázó igealakokra
- a főoldal és a szolgáltatási feltételek renderelt szövegének ellenőrzése
