### PR TITLE
Improve site authenticity and add live booking

### DIFF
--- a/APPS_SCRIPT_SETUP.md
+++ b/APPS_SCRIPT_SETUP.md
@@ -2,6 +2,11 @@
 
 This repository is configured to keep the website on GitHub Pages and send form submissions through a Google Apps Script web app.
 
+## Existing Apps Script URLs
+
+- Project editor: https://script.google.com/home/projects/1qHNojJ5rFOp0avlvqYrER06mX78zNrqIuQ4bKBFjz5dmnca5yc9L3Qnr/edit
+- Production web app: https://script.google.com/macros/s/AKfycbztbd9BZ55jNSTu4TIGgwk4mvIHteoyPhiB_qbzvRl4MM7T5XYq1axQNxhbudFutvht/exec
+
 ## What this does
 
 - The React site stays fully static on GitHub Pages.

--- a/APPS_SCRIPT_SETUP.md
+++ b/APPS_SCRIPT_SETUP.md
@@ -32,6 +32,10 @@ This repository is configured to keep the website on GitHub Pages and send form 
 
 The added Calendar permission is required to read busy periods and create booked events. Existing deployments must be redeployed and authorized again after this change.
 
+For the existing web app, replace both files in the Apps Script editor, then open `Deploy -> Manage deployments`, edit the active web-app deployment, choose `New version`, and deploy it. Editing the existing deployment keeps its `/exec` URL. Authorize the new Calendar permission when prompted.
+
+Deploy the Apps Script update before merging the frontend PR; until the backend is updated, the new picker will show its safe calendar-unavailable state.
+
 ## Configure booking availability
 
 The defaults at the top of `apps-script/Code.gs` are:

--- a/APPS_SCRIPT_SETUP.md
+++ b/APPS_SCRIPT_SETUP.md
@@ -74,12 +74,12 @@ After the variable is set:
 
 ## Manual checks
 
-1. Confirm an existing Google Calendar event removes every overlapping 55-minute slot from the website.
-2. Book a free time using a test email address.
-3. Confirm the event appears in the configured Google Calendar and the test address receives an invitation.
-4. Open the site in a second browser and confirm the booked time is no longer available.
-5. Confirm a notification email arrives at the configured recipient.
-6. Submit the contact form and verify its email behavior.
+1. Confirm an existing Google Calendar event marked as busy removes every overlapping 55-minute slot from the website.
+2. Confirm an event marked as available does not remove overlapping slots.
+3. Book a free time using a test email address.
+4. Confirm the event appears in the configured Google Calendar and the test address receives an invitation.
+5. Open the site in a second browser and confirm the booked time is no longer available.
+6. Confirm a notification email arrives at the configured recipient.
 
 ## Important limitations
 

--- a/APPS_SCRIPT_SETUP.md
+++ b/APPS_SCRIPT_SETUP.md
@@ -5,20 +5,23 @@ This repository is configured to keep the website on GitHub Pages and send form 
 ## What this does
 
 - The React site stays fully static on GitHub Pages.
-- The appointment and contact forms post to a Google Apps Script web app.
-- Apps Script sends an email from `karacsony.barni@gmail.com` to `karacsony.barni@gmail.com`.
+- The appointment picker reads free times from the Google Calendar connected to the Apps Script project.
+- Calendar event titles and details stay server-side; the website receives only available start times.
+- Apps Script rechecks the selected time under a script lock, creates the 55-minute event, and sends the visitor a Google Calendar invitation.
+- The contact form and appointment booking post to the same Google Apps Script web app.
+- Apps Script sends a notification email to the configured recipient.
 - The email `replyTo` is set to the visitor's email address.
 
 ## Files to use
 
-- Apps Script server code: [`apps-script/Code.gs`](/home/kbarna/VSCodeProjects/integral-counseling/apps-script/Code.gs)
-- Apps Script manifest: [`apps-script/appsscript.json`](/home/kbarna/VSCodeProjects/integral-counseling/apps-script/appsscript.json)
+- Apps Script server code: [`apps-script/Code.gs`](apps-script/Code.gs)
+- Apps Script manifest: [`apps-script/appsscript.json`](apps-script/appsscript.json)
 
 ## Deploy the Apps Script web app
 
-1. Create a new standalone Google Apps Script project while signed in as `karacsony.barni@gmail.com`.
-2. Replace the default script content with [`apps-script/Code.gs`](/home/kbarna/VSCodeProjects/integral-counseling/apps-script/Code.gs).
-3. Replace the manifest with [`apps-script/appsscript.json`](/home/kbarna/VSCodeProjects/integral-counseling/apps-script/appsscript.json).
+1. Create a new standalone Google Apps Script project while signed in as the calendar owner.
+2. Replace the default script content with [`apps-script/Code.gs`](apps-script/Code.gs).
+3. Replace the manifest with [`apps-script/appsscript.json`](apps-script/appsscript.json).
 4. Save the project.
 5. Open `Deploy -> New deployment`.
 6. Choose deployment type `Web app`.
@@ -26,6 +29,20 @@ This repository is configured to keep the website on GitHub Pages and send form 
 8. Set `Who has access` to `Anyone`.
 9. Authorize the script when prompted.
 10. Copy the deployed `/exec` URL.
+
+The added Calendar permission is required to read busy periods and create booked events. Existing deployments must be redeployed and authorized again after this change.
+
+## Configure booking availability
+
+The defaults at the top of `apps-script/Code.gs` are:
+
+- Primary Google Calendar (`BOOKING_CALENDAR_ID` is empty).
+- Monday to Friday, 09:00–12:00 and 13:00–18:00 in `Europe/Budapest`.
+- 55-minute sessions starting every 30 minutes.
+- At least 24 hours' notice.
+- The next 14 dates with free times, within a 60-day horizon.
+
+To use another calendar, set `BOOKING_CALENDAR_ID` to its calendar ID. Adjust `WORKING_WINDOWS` and the other booking constants before redeploying if the defaults do not match your schedule.
 
 ## Connect GitHub Pages to the web app
 
@@ -53,10 +70,12 @@ After the variable is set:
 
 ## Manual checks
 
-1. Submit an appointment request on the live site.
-2. Confirm an email arrives in `karacsony.barni@gmail.com`.
-3. Reply to that email and confirm the reply goes to the visitor's email address.
-4. Submit the contact form and verify the same behavior.
+1. Confirm an existing Google Calendar event removes every overlapping 55-minute slot from the website.
+2. Book a free time using a test email address.
+3. Confirm the event appears in the configured Google Calendar and the test address receives an invitation.
+4. Open the site in a second browser and confirm the booked time is no longer available.
+5. Confirm a notification email arrives at the configured recipient.
+6. Submit the contact form and verify its email behavior.
 
 ## Important limitations
 

--- a/APPS_SCRIPT_SETUP.md
+++ b/APPS_SCRIPT_SETUP.md
@@ -6,6 +6,7 @@ This repository is configured to keep the website on GitHub Pages and send form 
 
 - Project editor: https://script.google.com/home/projects/1qHNojJ5rFOp0avlvqYrER06mX78zNrqIuQ4bKBFjz5dmnca5yc9L3Qnr/edit
 - Production web app: https://script.google.com/macros/s/AKfycbztbd9BZ55jNSTu4TIGgwk4mvIHteoyPhiB_qbzvRl4MM7T5XYq1axQNxhbudFutvht/exec
+- Version 3 library: https://script.google.com/macros/library/d/1qHNojJ5rFOp0avlvqYrER06mX78zNrqIuQ4bKBFjz5dmnca5yc9L3Qnr/3
 
 ## What this does
 

--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -398,6 +398,12 @@ function getBookingCalendar_() {
 
 function hasOverlappingEvent_(events, slotStart, slotEnd) {
   return events.some(function (event) {
+    if (
+      event.getTransparency() === CalendarApp.EventTransparency.TRANSPARENT
+    ) {
+      return false;
+    }
+
     return (
       event.getStartTime().getTime() < slotEnd.getTime() &&
       event.getEndTime().getTime() > slotStart.getTime()

--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -1,8 +1,42 @@
 const RESPONSE_SOURCE = "integral-counseling-apps-script";
 const RECIPIENT_EMAIL = "karacsony.barni@gmail.com";
 const MIN_SUBMISSION_DELAY_MS = 3000;
+const BOOKING_TIME_ZONE = "Europe/Budapest";
+const BOOKING_CALENDAR_ID = "";
+const BOOKING_DURATION_MINUTES = 55;
+const SLOT_STEP_MINUTES = 30;
+const BOOKING_HORIZON_DAYS = 60;
+const MAX_AVAILABLE_DATES = 14;
+const MIN_BOOKING_NOTICE_HOURS = 24;
+const WORKING_WINDOWS = [
+  { startHour: 9, startMinute: 0, endHour: 12, endMinute: 0 },
+  { startHour: 13, startMinute: 0, endHour: 18, endMinute: 0 },
+];
 
-function doGet() {
+function doGet(e) {
+  const params = (e && e.parameter) || {};
+
+  if (cleanString_(params.action) === "availability") {
+    const requestId = cleanString_(params.requestId);
+    const targetOrigin = normalizeOrigin_(cleanString_(params.origin));
+
+    try {
+      return createIframeResponse_({
+        ok: true,
+        requestId: requestId,
+        slots: getAvailableSlots_(),
+        timeZone: BOOKING_TIME_ZONE,
+      }, targetOrigin);
+    } catch (error) {
+      console.error("Failed to load calendar availability", error);
+      return createIframeResponse_({
+        ok: false,
+        requestId: requestId,
+        error: "Calendar availability could not be loaded.",
+      }, targetOrigin);
+    }
+  }
+
   return ContentService.createTextOutput(
     JSON.stringify({
       ok: true,
@@ -31,14 +65,25 @@ function doPost(e) {
 
     validatePayload_(payload);
 
-    MailApp.sendEmail({
-      to: RECIPIENT_EMAIL,
-      subject: buildSubject_(payload),
-      body: buildPlainTextBody_(payload),
-      htmlBody: buildHtmlBody_(payload),
-      replyTo: payload.email,
-      name: "Integral Counseling Website",
-    });
+    if (payload.formType === "appointment") {
+      bookAppointment_(payload);
+    }
+
+    try {
+      MailApp.sendEmail({
+        to: RECIPIENT_EMAIL,
+        subject: buildSubject_(payload),
+        body: buildPlainTextBody_(payload),
+        htmlBody: buildHtmlBody_(payload),
+        replyTo: payload.email,
+        name: "Integral Counseling Website",
+      });
+    } catch (emailError) {
+      if (payload.formType !== "appointment") {
+        throw emailError;
+      }
+      console.error("Appointment was booked, but notification email failed", emailError);
+    }
 
     return createIframeResponse_({
       ok: true,
@@ -51,6 +96,7 @@ function doPost(e) {
       ok: false,
       requestId: requestId,
       error: error && error.message ? error.message : String(error),
+      errorCode: error && error.errorCode ? error.errorCode : "",
     }, targetOrigin);
   }
 }
@@ -70,6 +116,7 @@ function normalizePayload_(e) {
     preferredDate: cleanString_(params.preferredDate),
     preferredDateLabel: cleanString_(params.preferredDateLabel),
     preferredTime: cleanString_(params.preferredTime),
+    slotStart: cleanString_(params.slotStart),
     startedAt: Number(params.startedAt || 0),
     website: cleanString_(params.website),
     receivedAt: new Date(),
@@ -102,12 +149,8 @@ function validatePayload_(payload) {
   }
 
   if (payload.formType === "appointment") {
-    if (!payload.preferredDate) {
-      throw new Error("Preferred date is required.");
-    }
-
-    if (!payload.preferredTime) {
-      throw new Error("Preferred time is required.");
+    if (!payload.slotStart || isNaN(new Date(payload.slotStart).getTime())) {
+      throw new Error("A valid calendar slot is required.");
     }
   }
 
@@ -118,7 +161,7 @@ function validatePayload_(payload) {
 
 function buildSubject_(payload) {
   if (payload.formType === "appointment") {
-    return "Website appointment request from " + payload.name;
+    return "Website appointment booked by " + payload.name;
   }
 
   return "Website contact request from " + payload.name;
@@ -228,7 +271,10 @@ function createIframeResponse_(payload, targetOrigin) {
       ok: Boolean(payload.ok),
       requestId: payload.requestId || "",
       error: payload.error || "",
+      errorCode: payload.errorCode || "",
       ignored: Boolean(payload.ignored),
+      slots: payload.slots || [],
+      timeZone: payload.timeZone || "",
     }) +
     ";window.top.postMessage(message," +
     JSON.stringify(targetOrigin) +
@@ -237,6 +283,150 @@ function createIframeResponse_(payload, targetOrigin) {
 
   return HtmlService.createHtmlOutput(html)
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+function getAvailableSlots_() {
+  const calendar = getBookingCalendar_();
+  const now = new Date();
+  const earliestStart = new Date(
+    now.getTime() + MIN_BOOKING_NOTICE_HOURS * 60 * 60 * 1000,
+  );
+  const horizonEnd = new Date(now);
+  horizonEnd.setDate(horizonEnd.getDate() + BOOKING_HORIZON_DAYS);
+  horizonEnd.setHours(23, 59, 59, 999);
+  const busyEvents = calendar.getEvents(earliestStart, horizonEnd);
+  const slots = [];
+  let availableDateCount = 0;
+  const day = new Date(now);
+  day.setHours(0, 0, 0, 0);
+  day.setDate(day.getDate() + 1);
+
+  for (let dayOffset = 0; dayOffset < BOOKING_HORIZON_DAYS; dayOffset += 1) {
+    const dayOfWeek = day.getDay();
+    let slotsAddedForDate = 0;
+
+    if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+      WORKING_WINDOWS.forEach(function (window) {
+        const slotStart = new Date(day);
+        slotStart.setHours(window.startHour, window.startMinute, 0, 0);
+        const windowEnd = new Date(day);
+        windowEnd.setHours(window.endHour, window.endMinute, 0, 0);
+
+        while (true) {
+          const slotEnd = new Date(
+            slotStart.getTime() + BOOKING_DURATION_MINUTES * 60 * 1000,
+          );
+
+          if (slotEnd.getTime() > windowEnd.getTime()) {
+            break;
+          }
+
+          if (
+            slotStart.getTime() >= earliestStart.getTime() &&
+            !hasOverlappingEvent_(busyEvents, slotStart, slotEnd)
+          ) {
+            slots.push(slotStart.toISOString());
+            slotsAddedForDate += 1;
+          }
+
+          slotStart.setMinutes(slotStart.getMinutes() + SLOT_STEP_MINUTES);
+        }
+      });
+    }
+
+    if (slotsAddedForDate > 0) {
+      availableDateCount += 1;
+      if (availableDateCount >= MAX_AVAILABLE_DATES) {
+        break;
+      }
+    }
+
+    day.setDate(day.getDate() + 1);
+  }
+
+  return slots;
+}
+
+function bookAppointment_(payload) {
+  const lock = LockService.getScriptLock();
+  lock.waitLock(10000);
+
+  try {
+    const slotStart = new Date(payload.slotStart);
+    const availableSlots = getAvailableSlots_();
+    const requestedTimestamp = slotStart.getTime();
+    const isAvailable = availableSlots.some(function (slot) {
+      return new Date(slot).getTime() === requestedTimestamp;
+    });
+
+    if (!isAvailable) {
+      throw createCodedError_(
+        "SLOT_UNAVAILABLE",
+        "That appointment is no longer available.",
+      );
+    }
+
+    const slotEnd = new Date(
+      slotStart.getTime() + BOOKING_DURATION_MINUTES * 60 * 1000,
+    );
+    const calendar = getBookingCalendar_();
+    const title =
+      (payload.language === "en" ? "First conversation – " : "Első beszélgetés – ") +
+      payload.name;
+
+    calendar.createEvent(title, slotStart, slotEnd, {
+      description: buildCalendarDescription_(payload),
+      guests: payload.email,
+      sendInvites: true,
+    });
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+function getBookingCalendar_() {
+  const calendar = BOOKING_CALENDAR_ID
+    ? CalendarApp.getCalendarById(BOOKING_CALENDAR_ID)
+    : CalendarApp.getDefaultCalendar();
+
+  if (!calendar) {
+    throw new Error("Booking calendar is not available.");
+  }
+
+  return calendar;
+}
+
+function hasOverlappingEvent_(events, slotStart, slotEnd) {
+  return events.some(function (event) {
+    return (
+      event.getStartTime().getTime() < slotEnd.getTime() &&
+      event.getEndTime().getTime() > slotStart.getTime()
+    );
+  });
+}
+
+function buildCalendarDescription_(payload) {
+  const lines = [
+    "Website appointment booking",
+    "Name: " + payload.name,
+    "Email: " + payload.email,
+  ];
+
+  if (payload.phone) {
+    lines.push("Phone: " + payload.phone);
+  }
+
+  if (payload.message) {
+    lines.push("", "Message:", payload.message);
+  }
+
+  return lines.join("\n");
+}
+
+function createCodedError_(code, message) {
+  const error = new Error(message);
+  error.errorCode = code;
+  return error;
 }
 
 function normalizeOrigin_(origin) {

--- a/apps-script/appsscript.json
+++ b/apps-script/appsscript.json
@@ -3,6 +3,7 @@
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "oauthScopes": [
-    "https://www.googleapis.com/auth/script.send_mail"
+    "https://www.googleapis.com/auth/script.send_mail",
+    "https://www.googleapis.com/auth/calendar"
   ]
 }

--- a/client/src/components/AppointmentBooking.tsx
+++ b/client/src/components/AppointmentBooking.tsx
@@ -366,9 +366,6 @@ export default function AppointmentBooking() {
                         )}
                       />
 
-                      <p className="text-xs leading-relaxed text-muted-foreground">
-                        {t("availability.privacy")}
-                      </p>
                     </div>
                   )}
                 </div>

--- a/client/src/components/AppointmentBooking.tsx
+++ b/client/src/components/AppointmentBooking.tsx
@@ -2,18 +2,27 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import SubmissionSuccessMessage from "@/components/SubmissionSuccessMessage";
 import SubmissionErrorMessage from "@/components/SubmissionErrorMessage";
-import { Calendar, Clock, ArrowRight, MapPin, MessageCircle } from "lucide-react";
+import { AlertCircle, ArrowRight, Calendar, Clock, LoaderCircle, MapPin, MessageCircle, RefreshCw } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { createAppointmentSchema, type AppointmentInput } from "@/lib/forms";
 import { THERAPIST_EMAIL } from "@/lib/contactDetails";
-import { submitWebsiteForm } from "@/lib/formSubmission";
+import {
+  submitWebsiteForm,
+  WebsiteFormSubmissionError,
+} from "@/lib/formSubmission";
+import {
+  getCalendarAvailability,
+  type CalendarAvailability,
+} from "@/lib/calendarAvailability";
+import { cn } from "@/lib/utils";
+
+const DEFAULT_TIME_ZONE = "Europe/Budapest";
 
 export default function AppointmentBooking() {
   const { t, i18n } = useTranslation("appointment");
@@ -21,6 +30,13 @@ export default function AppointmentBooking() {
   const honeypotRef = useRef<HTMLInputElement>(null);
   const [successMessageVisible, setSuccessMessageVisible] = useState(false);
   const [errorMessageVisible, setErrorMessageVisible] = useState(false);
+  const [slotConflict, setSlotConflict] = useState(false);
+  const [availability, setAvailability] = useState<CalendarAvailability>({
+    slots: [],
+    timeZone: DEFAULT_TIME_ZONE,
+  });
+  const [availabilityLoading, setAvailabilityLoading] = useState(true);
+  const [availabilityError, setAvailabilityError] = useState(false);
   const validationSchema = useMemo(() => createAppointmentSchema(t), [t]);
 
   const form = useForm<AppointmentInput>({
@@ -31,44 +47,74 @@ export default function AppointmentBooking() {
       phone: "",
       preferredDate: "",
       preferredTime: "",
-      message: ""
-    }
+      message: "",
+    },
   });
 
-  // Available time slots use locale-neutral values and localized display labels.
-  const timeSlots = [
-    "09:00", "09:30", "10:00", "10:30", "11:00", "11:30",
-    "13:00", "13:30", "14:00", "14:30", "15:00", "15:30",
-    "16:00", "16:30", "17:00", "17:30"
-  ];
+  const locale = i18n.language === "hu" ? "hu-HU" : "en-US";
+  const selectedDate = form.watch("preferredDate");
+  const selectedSlot = form.watch("preferredTime");
 
-  // Generate available dates (next 30 weekdays)
-  const getAvailableDates = () => {
-    const dates: Date[] = [];
-    const today = new Date();
-    let currentDate = new Date(today);
-    currentDate.setDate(currentDate.getDate() + 1); // Start from tomorrow
+  const slotsByDate = useMemo(() => {
+    const groups = new Map<string, string[]>();
 
-    while (dates.length < 30) {
-      // Skip weekends (Saturday = 6, Sunday = 0)
-      if (currentDate.getDay() !== 0 && currentDate.getDay() !== 6) {
-        dates.push(new Date(currentDate));
-      }
-      currentDate.setDate(currentDate.getDate() + 1);
+    for (const slot of availability.slots) {
+      const dateKey = getDateKey(slot, availability.timeZone);
+      const dateSlots = groups.get(dateKey) || [];
+      dateSlots.push(slot);
+      groups.set(dateKey, dateSlots);
     }
-    return dates;
-  };
 
-  const availableDates = getAvailableDates();
+    return groups;
+  }, [availability]);
+
+  const availableDates = Array.from(slotsByDate.keys());
+  const selectedDateSlots = slotsByDate.get(selectedDate) || [];
+
+  const loadAvailability = useCallback(async () => {
+    setAvailabilityLoading(true);
+    setAvailabilityError(false);
+
+    try {
+      const nextAvailability = await getCalendarAvailability();
+      setAvailability(nextAvailability);
+
+      const currentDate = form.getValues("preferredDate");
+      const nextDates = nextAvailability.slots.map((slot) =>
+        getDateKey(slot, nextAvailability.timeZone),
+      );
+      if (!currentDate || !nextDates.includes(currentDate)) {
+        form.setValue("preferredDate", nextDates[0] || "");
+        form.setValue("preferredTime", "");
+      }
+    } catch (error) {
+      console.error("Error loading calendar availability:", error);
+      setAvailabilityError(true);
+    } finally {
+      setAvailabilityLoading(false);
+    }
+  }, [form]);
+
+  useEffect(() => {
+    void loadAvailability();
+  }, [loadAvailability]);
+
   const bookingDetails = [
     { key: "duration", icon: Clock },
     { key: "format", icon: MapPin },
-    { key: "reply", icon: MessageCircle },
+    { key: "calendar", icon: MessageCircle },
   ] as const;
+
+  const clearSubmissionMessages = () => {
+    setSuccessMessageVisible(false);
+    setErrorMessageVisible(false);
+    setSlotConflict(false);
+  };
 
   const handleSubmit = async (data: AppointmentInput) => {
     setSuccessMessageVisible(false);
     setErrorMessageVisible(false);
+    setSlotConflict(false);
 
     try {
       await submitWebsiteForm({
@@ -78,8 +124,9 @@ export default function AppointmentBooking() {
         email: data.email,
         phone: data.phone,
         preferredDate: data.preferredDate,
-        preferredDateLabel: formatDateValue(data.preferredDate),
-        preferredTime: formatTimeValue(data.preferredTime),
+        preferredDateLabel: formatSlotDate(data.preferredTime),
+        preferredTime: formatSlotTime(data.preferredTime),
+        slotStart: data.preferredTime,
         message: data.message,
         startedAt: startedAtRef.current,
         website: honeypotRef.current?.value || "",
@@ -91,41 +138,45 @@ export default function AppointmentBooking() {
       }
       startedAtRef.current = Date.now();
       setSuccessMessageVisible(true);
+      await loadAvailability();
     } catch (error) {
       console.error("Error booking appointment:", error);
+      const conflict =
+        error instanceof WebsiteFormSubmissionError &&
+        error.code === "SLOT_UNAVAILABLE";
+      setSlotConflict(conflict);
       setErrorMessageVisible(true);
+
+      if (conflict) {
+        form.setValue("preferredTime", "");
+        await loadAvailability();
+      }
     }
   };
 
-  const formatDate = (date: Date) => {
-    return new Intl.DateTimeFormat(i18n.language === "hu" ? "hu-HU" : "en-US", {
+  const formatSlotDate = (slot: string) =>
+    new Intl.DateTimeFormat(locale, {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      timeZone: availability.timeZone,
+    }).format(new Date(slot));
+
+  const formatDateButton = (slot: string) =>
+    new Intl.DateTimeFormat(locale, {
       weekday: "short",
       month: "short",
       day: "numeric",
-      year: "numeric"
-    }).format(date);
-  };
+      timeZone: availability.timeZone,
+    }).format(new Date(slot));
 
-  const getDateValue = (date: Date) => {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-
-    return `${year}-${month}-${day}`;
-  };
-
-  const formatDateValue = (value: string) => {
-    const [year, month, day] = value.split("-").map(Number);
-    return formatDate(new Date(year, month - 1, day));
-  };
-
-  const formatTimeValue = (value: string) => {
-    const [hour, minute] = value.split(":").map(Number);
-    return new Intl.DateTimeFormat(i18n.language === "hu" ? "hu-HU" : "en-US", {
+  const formatSlotTime = (slot: string) =>
+    new Intl.DateTimeFormat(locale, {
       hour: "numeric",
       minute: "2-digit",
-    }).format(new Date(2000, 0, 1, hour, minute));
-  };
+      timeZone: availability.timeZone,
+    }).format(new Date(slot));
 
   return (
     <section className="bg-card py-20 sm:py-28">
@@ -179,24 +230,16 @@ export default function AppointmentBooking() {
                   className="hidden"
                   aria-hidden="true"
                 />
-                {/* Personal Information */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                   <FormField
                     control={form.control}
                     name="name"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>
-                          {t("form.name")} ({t("form.required")})
-                        </FormLabel>
+                        <FormLabel>{t("form.name")} ({t("form.required")})</FormLabel>
                         <FormControl>
-                          <Input
-                            {...field}
-                            autoComplete="name"
-                            required
-                            placeholder={t("form.name_placeholder")}
-                            data-testid="input-booking-name"
-                          />
+                          <Input {...field} autoComplete="name" required placeholder={t("form.name_placeholder")} data-testid="input-booking-name" />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -207,18 +250,9 @@ export default function AppointmentBooking() {
                     name="email"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>
-                          {t("form.email")} ({t("form.required")})
-                        </FormLabel>
+                        <FormLabel>{t("form.email")} ({t("form.required")})</FormLabel>
                         <FormControl>
-                          <Input
-                            type="email"
-                            {...field}
-                            autoComplete="email"
-                            required
-                            placeholder={t("form.email_placeholder")}
-                            data-testid="input-booking-email"
-                          />
+                          <Input type="email" {...field} autoComplete="email" required placeholder={t("form.email_placeholder")} data-testid="input-booking-email" />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -231,112 +265,132 @@ export default function AppointmentBooking() {
                   name="phone"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>{t('form.phone')}</FormLabel>
+                      <FormLabel>{t("form.phone")}</FormLabel>
                       <FormControl>
-                        <Input
-                          type="tel"
-                          {...field}
-                          autoComplete="tel"
-                          placeholder={t("form.phone_placeholder")}
-                          className="max-w-xs"
-                          data-testid="input-booking-phone"
-                        />
+                        <Input type="tel" {...field} autoComplete="tel" placeholder={t("form.phone_placeholder")} className="max-w-xs" data-testid="input-booking-phone" />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
 
-                {/* Date and Time Selection */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <FormField
-                    control={form.control}
-                    name="preferredDate"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>
-                          {t("form.date")} ({t("form.required")})
-                        </FormLabel>
-                        <Select onValueChange={field.onChange} value={field.value}>
-                          <FormControl>
-                            <SelectTrigger
-                              aria-required="true"
-                              data-testid="select-booking-date"
-                            >
-                              <SelectValue placeholder={t('form.date_placeholder')} />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {availableDates.map((date) => (
-                              <SelectItem key={getDateValue(date)} value={getDateValue(date)}>
-                                {formatDate(date)}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="preferredTime"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>
-                          {t("form.time")} ({t("form.required")})
-                        </FormLabel>
-                        <Select onValueChange={field.onChange} value={field.value}>
-                          <FormControl>
-                            <SelectTrigger
-                              aria-required="true"
-                              data-testid="select-booking-time"
-                            >
-                              <SelectValue placeholder={t('form.time_placeholder')} />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {timeSlots.map((time) => (
-                              <SelectItem key={time} value={time}>
-                                <div className="flex items-center gap-2">
-                                  <Clock className="h-4 w-4" aria-hidden="true" />
-                                  {formatTimeValue(time)}
-                                </div>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                <div className="rounded-2xl border border-border bg-muted/20 p-4 sm:p-5">
+                  {availabilityLoading ? (
+                    <div className="flex min-h-32 items-center justify-center gap-3 text-muted-foreground" role="status">
+                      <LoaderCircle className="h-5 w-5 animate-spin" aria-hidden="true" />
+                      <span>{t("availability.loading")}</span>
+                    </div>
+                  ) : availabilityError ? (
+                    <div className="flex min-h-32 flex-col items-center justify-center gap-3 text-center" role="alert">
+                      <AlertCircle className="h-6 w-6 text-destructive" aria-hidden="true" />
+                      <p className="text-sm text-muted-foreground">{t("availability.error")}</p>
+                      <Button type="button" variant="outline" size="sm" onClick={() => void loadAvailability()}>
+                        <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
+                        {t("availability.retry")}
+                      </Button>
+                    </div>
+                  ) : availableDates.length === 0 ? (
+                    <div className="flex min-h-32 flex-col items-center justify-center gap-2 text-center" role="status">
+                      <Calendar className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+                      <p className="font-medium">{t("availability.empty_title")}</p>
+                      <p className="text-sm text-muted-foreground">{t("availability.empty_description")}</p>
+                    </div>
+                  ) : (
+                    <div className="space-y-5">
+                      <FormField
+                        control={form.control}
+                        name="preferredDate"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>{t("form.date")} ({t("form.required")})</FormLabel>
+                            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3" role="group" aria-label={t("form.date")}>
+                              {availableDates.map((dateKey) => {
+                                const firstSlot = slotsByDate.get(dateKey)?.[0] || "";
+                                return (
+                                  <button
+                                    key={dateKey}
+                                    type="button"
+                                    aria-pressed={field.value === dateKey}
+                                    onClick={() => {
+                                      clearSubmissionMessages();
+                                      field.onChange(dateKey);
+                                      form.setValue("preferredTime", "", { shouldValidate: true });
+                                    }}
+                                    className={cn(
+                                      "min-h-12 rounded-xl border px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                                      field.value === dateKey
+                                        ? "border-primary bg-primary text-primary-foreground"
+                                        : "border-border bg-background hover:border-primary/50 hover:bg-primary/5",
+                                    )}
+                                  >
+                                    {formatDateButton(firstSlot)}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <FormField
+                        control={form.control}
+                        name="preferredTime"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>{t("form.time")} ({t("form.required")})</FormLabel>
+                            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4" role="group" aria-label={t("form.time")}>
+                              {selectedDateSlots.map((slot) => (
+                                <button
+                                  key={slot}
+                                  type="button"
+                                  aria-pressed={field.value === slot}
+                                  onClick={() => {
+                                    clearSubmissionMessages();
+                                    field.onChange(slot);
+                                  }}
+                                  className={cn(
+                                    "flex min-h-11 items-center justify-center gap-1.5 rounded-xl border px-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                                    field.value === slot
+                                      ? "border-primary bg-primary text-primary-foreground"
+                                      : "border-border bg-background hover:border-primary/50 hover:bg-primary/5",
+                                  )}
+                                >
+                                  <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+                                  {formatSlotTime(slot)}
+                                </button>
+                              ))}
+                            </div>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <p className="text-xs leading-relaxed text-muted-foreground">
+                        {t("availability.privacy")}
+                      </p>
+                    </div>
+                  )}
                 </div>
 
-                {/* Additional Message */}
                 <FormField
                   control={form.control}
                   name="message"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>{t('form.message')}</FormLabel>
+                      <FormLabel>{t("form.message")}</FormLabel>
                       <FormControl>
-                        <Textarea
-                          {...field}
-                          placeholder={t('form.message_placeholder')}
-                          rows={3}
-                          data-testid="textarea-booking-message"
-                        />
+                        <Textarea {...field} placeholder={t("form.message_placeholder")} rows={3} data-testid="textarea-booking-message" />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
 
-                {/* Submit Button */}
                 <Button
-                  type="submit" 
+                  type="submit"
                   className="group min-h-12 w-full rounded-full text-base"
-                  disabled={form.formState.isSubmitting}
+                  disabled={form.formState.isSubmitting || availabilityLoading || availabilityError || !selectedSlot}
                   data-testid="button-book-appointment"
                 >
                   {form.formState.isSubmitting ? t("form.booking") : t("form.submit")}
@@ -344,28 +398,20 @@ export default function AppointmentBooking() {
                 </Button>
 
                 {successMessageVisible && (
-                  <SubmissionSuccessMessage
-                    title={t("success.title")}
-                    description={t("success.description")}
-                  />
+                  <SubmissionSuccessMessage title={t("success.title")} description={t("success.description")} />
                 )}
 
                 {errorMessageVisible && (
                   <SubmissionErrorMessage
-                    title={t("error.title")}
-                    description={t("error.description")}
+                    title={slotConflict ? t("conflict.title") : t("error.title")}
+                    description={slotConflict ? t("conflict.description") : t("error.description")}
                     email={THERAPIST_EMAIL}
-                    emailAction={t("error.email_action", {
-                      email: THERAPIST_EMAIL,
-                    })}
+                    emailAction={t("error.email_action", { email: THERAPIST_EMAIL })}
                   />
                 )}
 
-                {/* Disclaimer */}
                 <div className="rounded-2xl bg-muted/50 p-4 text-center text-sm leading-relaxed text-muted-foreground">
-                  <p data-testid="booking-disclaimer">
-                    {t('disclaimer')}
-                  </p>
+                  <p data-testid="booking-disclaimer">{t("disclaimer")}</p>
                 </div>
               </form>
             </Form>
@@ -374,4 +420,15 @@ export default function AppointmentBooking() {
       </div>
     </section>
   );
+}
+
+function getDateKey(slot: string, timeZone: string) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone,
+  }).formatToParts(new Date(slot));
+  const values = Object.fromEntries(parts.map(({ type, value }) => [type, value]));
+  return `${values.year}-${values.month}-${values.day}`;
 }

--- a/client/src/components/Contact.tsx
+++ b/client/src/components/Contact.tsx
@@ -6,7 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import SubmissionSuccessMessage from "@/components/SubmissionSuccessMessage";
 import SubmissionErrorMessage from "@/components/SubmissionErrorMessage";
-import { Phone, Mail, MapPin } from "lucide-react";
+import { Clock3, Mail, MapPin, MessageCircle, Phone } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMemo, useRef, useState } from "react";
@@ -23,6 +23,11 @@ export default function Contact() {
   const [successMessageVisible, setSuccessMessageVisible] = useState(false);
   const [errorMessageVisible, setErrorMessageVisible] = useState(false);
   const validationSchema = useMemo(() => createContactInquirySchema(t), [t]);
+  const practicalDetails = [
+    { key: "session", icon: Clock3 },
+    { key: "format", icon: MapPin },
+    { key: "reply", icon: MessageCircle },
+  ] as const;
 
   const form = useForm<ContactInquiryInput>({
     resolver: zodResolver(validationSchema),
@@ -78,6 +83,16 @@ export default function Contact() {
           <p className="mt-5 max-w-2xl text-lg leading-relaxed text-muted-foreground" data-testid="contact-subtitle">
             {tHome("contact_section.subtitle")}
           </p>
+          <ul className="mt-7 flex flex-col gap-3 text-sm text-muted-foreground sm:flex-row sm:flex-wrap sm:gap-x-6">
+            {practicalDetails.map(({ key, icon: Icon }) => (
+              <li key={key} className="flex items-center gap-2">
+                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <Icon className="h-4 w-4" strokeWidth={1.8} aria-hidden="true" />
+                </span>
+                {tHome(`contact_section.details.${key}`)}
+              </li>
+            ))}
+          </ul>
         </div>
 
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1.08fr_0.92fr]">

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -132,9 +132,9 @@ export default function Header() {
             <LanguageSwitcher />
             <Button asChild className="rounded-full px-5">
               <Link
-                href={getLocalizedPath("/#appointment-booking", i18n.language)}
+                href={getLocalizedPath("/#contact", i18n.language)}
                 onClick={(event) =>
-                  handleSectionLink(event, "appointment-booking")
+                  handleSectionLink(event, "contact")
                 }
                 data-testid="button-book-consultation"
               >
@@ -201,9 +201,9 @@ export default function Header() {
                 <LanguageSwitcher />
                 <Button asChild className="w-full">
                   <Link
-                    href={getLocalizedPath("/#appointment-booking", i18n.language)}
+                    href={getLocalizedPath("/#contact", i18n.language)}
                     onClick={(event) =>
-                      handleSectionLink(event, "appointment-booking", true)
+                      handleSectionLink(event, "contact", true)
                     }
                     data-testid="mobile-button-book-consultation"
                   >

--- a/client/src/components/Hero.tsx
+++ b/client/src/components/Hero.tsx
@@ -33,10 +33,10 @@ export default function Hero() {
 
           <div className="mt-9 flex flex-col gap-3 sm:flex-row">
             <a
-              href="#appointment-booking"
+              href="#contact"
               onClick={(event) => {
                 event.preventDefault();
-                scrollToSection("appointment-booking");
+                scrollToSection("contact");
               }}
               className="group inline-flex min-h-12 items-center justify-center rounded-full bg-primary px-7 py-3 font-semibold text-primary-foreground shadow-[0_12px_30px_-12px_hsl(var(--primary)/0.65)] transition hover:-translate-y-0.5 hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none"
               data-testid="button-schedule-consultation"

--- a/client/src/components/Services.tsx
+++ b/client/src/components/Services.tsx
@@ -83,10 +83,10 @@ export default function Services() {
               })}
 
               <a
-                href="#appointment-booking"
+                href="#contact"
                 onClick={(event) => {
                   event.preventDefault();
-                  scrollToSection("appointment-booking");
+                  scrollToSection("contact");
                 }}
                 className="group mt-5 inline-flex min-h-12 items-center rounded-full bg-accent px-6 py-3 font-semibold text-foreground transition hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background focus-visible:ring-offset-2 focus-visible:ring-offset-foreground"
                 data-testid="button-learn-more-individual"

--- a/client/src/i18n/locales/en/about.json
+++ b/client/src/i18n/locales/en/about.json
@@ -4,7 +4,7 @@
   "lead": "As a software developer, I work with complex systems. As a final-year student at the Integral Academy, I bring the same curiosity to the inner world of people.",
   "story": {
     "systems": "My technology background taught me to ask precise questions, look for connections, and find the next possible step in complex situations. In counseling, I combine that clarity with attentive, human presence.",
-    "integral": "The integral perspective resonates with me because it does not reduce a person to a single explanation. It makes room for thoughts, emotions, the body, relationships, and the wider context in which we live."
+    "integral": "The integral perspective makes room for thoughts, emotions, the body, relationships, and the wider context in which we live. This many-sided way of understanding people resonates with me."
   },
   "facts": {
     "training": {

--- a/client/src/i18n/locales/en/appointment.json
+++ b/client/src/i18n/locales/en/appointment.json
@@ -1,11 +1,11 @@
 {
   "eyebrow": "A first step",
   "title": "Let’s begin with a conversation.",
-  "subtitle": "You do not need to explain everything in advance. Let me know when you could meet, and I’ll reply within 24 hours.",
+  "subtitle": "You do not need to explain everything in advance. Let me know when you could meet, and I’ll usually reply within one business day.",
   "details": {
     "duration": "One session is 55 minutes",
     "format": "In Budapest or online",
-    "reply": "A reply within 24 hours"
+    "reply": "A reply usually within one business day"
   },
   "form": {
     "title": "When could we meet?",
@@ -32,7 +32,7 @@
   },
   "success": {
     "title": "Appointment request sent",
-    "description": "Your appointment request was sent successfully. I'll contact you within 24 hours."
+    "description": "Your appointment request was sent successfully. I’ll usually contact you within one business day."
   },
   "error": {
     "title": "Appointment request not sent",

--- a/client/src/i18n/locales/en/appointment.json
+++ b/client/src/i18n/locales/en/appointment.json
@@ -1,14 +1,14 @@
 {
   "eyebrow": "A first step",
-  "title": "Let’s begin with a conversation.",
-  "subtitle": "You do not need to explain everything in advance. Let me know when you could meet, and I’ll usually reply within one business day.",
+  "title": "Choose a time that is actually available.",
+  "subtitle": "The calendar shows appointments based on my current Google Calendar availability. Your selected session is added to the calendar immediately when you book.",
   "details": {
     "duration": "One session is 55 minutes",
     "format": "In Budapest or online",
-    "reply": "A reply usually within one business day"
+    "calendar": "Live Google Calendar availability"
   },
   "form": {
-    "title": "When could we meet?",
+    "title": "Book an appointment",
     "name": "Full Name",
     "name_placeholder": "Enter your full name",
     "email": "Email Address",
@@ -17,26 +17,38 @@
     "phone_placeholder": "+36 30 123 4567",
     "service": "Service",
     "service_placeholder": "Select a service",
-    "date": "Preferred Date",
+    "date": "Available Date",
     "date_placeholder": "Choose a date",
-    "time": "Preferred Time",
+    "time": "Available Time",
     "time_placeholder": "Select a time",
     "message": "Additional Information",
     "message_placeholder": "Anything you’d like me to know beforehand...",
     "required": "required",
-    "submit": "Request a first conversation",
-    "booking": "Sending request..."
+    "submit": "Book this appointment",
+    "booking": "Booking..."
   },
   "services": {
     "individual": "Integral Counseling (55 min)"
   },
   "success": {
-    "title": "Appointment request sent",
-    "description": "Your appointment request was sent successfully. I’ll usually contact you within one business day."
+    "title": "Your appointment is booked",
+    "description": "The session was added to Google Calendar, and you will also receive an invitation by email."
+  },
+  "availability": {
+    "loading": "Loading available times from Google Calendar...",
+    "error": "Calendar availability cannot be loaded right now. Please retry or email me directly.",
+    "retry": "Try again",
+    "empty_title": "No appointments are currently available",
+    "empty_description": "Please email me and we can look for another option.",
+    "privacy": "Only free time slots are shown; calendar event titles and details are never sent to the website."
+  },
+  "conflict": {
+    "title": "Someone just booked this time",
+    "description": "I refreshed the calendar. Please choose another available appointment."
   },
   "error": {
     "title": "Appointment request not sent",
-    "description": "We couldn't send your request. Your details are still here, so you can try again or contact me directly.",
+    "description": "We couldn't book the appointment. Your details are still here, so you can try again or contact me directly.",
     "email_action": "Email me at {{email}}"
   },
   "validation": {

--- a/client/src/i18n/locales/en/appointment.json
+++ b/client/src/i18n/locales/en/appointment.json
@@ -1,11 +1,11 @@
 {
   "eyebrow": "A first step",
-  "title": "Choose a time that is actually available.",
-  "subtitle": "The calendar shows appointments based on my current Google Calendar availability. Your selected session is added to the calendar immediately when you book.",
+  "title": "Choose a time that works for you.",
+  "subtitle": "Book easily from the available appointment times.",
   "details": {
     "duration": "One session is 55 minutes",
     "format": "In Budapest or online",
-    "calendar": "Live Google Calendar availability"
+    "calendar": "Instant confirmation"
   },
   "form": {
     "title": "Book an appointment",
@@ -32,19 +32,18 @@
   },
   "success": {
     "title": "Your appointment is booked",
-    "description": "The session was added to Google Calendar, and you will also receive an invitation by email."
+    "description": "You will also receive the invitation by email."
   },
   "availability": {
-    "loading": "Loading available times from Google Calendar...",
-    "error": "Calendar availability cannot be loaded right now. Please retry or email me directly.",
+    "loading": "Loading available times...",
+    "error": "Available times cannot be loaded right now. Please retry or email me directly.",
     "retry": "Try again",
     "empty_title": "No appointments are currently available",
-    "empty_description": "Please email me and we can look for another option.",
-    "privacy": "Only free time slots are shown; calendar event titles and details are never sent to the website."
+    "empty_description": "Please email me and we can look for another option."
   },
   "conflict": {
     "title": "Someone just booked this time",
-    "description": "I refreshed the calendar. Please choose another available appointment."
+    "description": "I refreshed the available times. Please choose another one."
   },
   "error": {
     "title": "Appointment request not sent",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -24,7 +24,7 @@
   "skip_to_content": "Skip to main content",
   "meta": {
     "home": {
-      "title": "Barna Karácsony — Integral Counselor Candidate | Budapest and online",
+      "title": "Barna Karácsony — Integral counselor in training | Budapest and online",
       "description": "Attentive, practical integral counseling for self-knowledge, decisions, and understanding recurring patterns, in Budapest or online."
     },
     "terms": {

--- a/client/src/i18n/locales/en/contact.json
+++ b/client/src/i18n/locales/en/contact.json
@@ -14,17 +14,17 @@
     "contact_method": "Preferred Contact Method",
     "contact_method_placeholder": "How would you like to be contacted?",
     "message": "Message",
-    "message_placeholder": "Share any context or questions you’d like to discuss...",
+    "message_placeholder": "Briefly share what brings you here and suggest two or three times that could work...",
     "required": "required",
-    "submit": "Send Message",
+    "submit": "Request a first conversation",
     "sending": "Sending..."
   },
   "success": {
-    "title": "Message sent",
-    "description": "Your message was sent successfully. Thank you for reaching out — I'll get back to you within 24 hours."
+    "title": "Request sent",
+    "description": "Your message was sent successfully. Thank you for reaching out — I usually reply within one business day."
   },
   "error": {
-    "title": "Message not sent",
+    "title": "Request not sent",
     "description": "We couldn't send your message. Your details are still here, so you can try again or contact me directly.",
     "email_action": "Email me at {{email}}"
   },
@@ -52,7 +52,7 @@
     "address_line2": "Hungary",
     "hours": "Availability",
     "hours_by_appointment": "Weekdays and weekends by appointment",
-    "response_time": "Usual response time: 24 hours"
+    "response_time": "Usual response time: one business day"
   },
   "emergency": {
     "title": "Need urgent help?",

--- a/client/src/i18n/locales/en/footer.json
+++ b/client/src/i18n/locales/en/footer.json
@@ -1,6 +1,6 @@
 {
   "practice_title": "Barna Karácsony",
-  "practice_description": "Integral Counselor Candidate — sessions in Hungarian and English.",
+  "practice_description": "Integral counselor in training — sessions in Hungarian and English.",
   "license": "Integral Academy final-year student, Budapest — Non‑medical counseling",
   "quick_links": "Quick Links",
   "about": "About",

--- a/client/src/i18n/locales/en/home.json
+++ b/client/src/i18n/locales/en/home.json
@@ -17,7 +17,7 @@
   "contact_section": {
     "eyebrow": "A first step",
     "title": "Let’s begin with a conversation.",
-    "subtitle": "Briefly tell me what brings you here and suggest two or three times that could work. This is not a live calendar; we will confirm the meeting personally.",
+    "subtitle": "Choose from appointment times shown as genuinely available in Google Calendar.",
     "form_title": "Request a first conversation",
     "details": {
       "session": "The first meeting is a full 55-minute session",

--- a/client/src/i18n/locales/en/home.json
+++ b/client/src/i18n/locales/en/home.json
@@ -1,13 +1,13 @@
 {
   "hero": {
-    "eyebrow": "Barna Karácsony · Integral Counselor Candidate",
-    "title": "Understand what is happening within you. Move toward what is truly yours.",
-    "subtitle": "If you feel stuck in a decision, caught in a recurring pattern, or simply want to see yourself more clearly, I offer an attentive and practical space for our work together.",
+    "eyebrow": "Barna Karácsony · Integral counselor in training",
+    "title": "See more clearly when many things pull at once.",
+    "subtitle": "As an integral counselor in training, I combine analytical thinking with attentive, human presence. You can come with decisions, recurring patterns, or a sense of overload.",
     "cta": "How I work",
     "appointment": "Request a first conversation",
     "profile_alt": "Barna Karácsony sitting in a yellow armchair",
-    "note": "I do not offer ready-made answers. I help you see more clearly what is happening—and what the next real step might be.",
-    "note_label": "Shared attention, at your pace",
+    "note": "I like to ask precise questions, look for connections, and give time to what has not yet come together.",
+    "note_label": "Clarity and human attention",
     "details": {
       "duration": "55-minute sessions",
       "format": "In Budapest or online",
@@ -15,9 +15,14 @@
     }
   },
   "contact_section": {
-    "eyebrow": "Contact",
-    "title": "Still have a question before requesting a session?",
-    "subtitle": "Send me a short message, or reach me directly by phone or email.",
-    "form_title": "Write to me"
+    "eyebrow": "A first step",
+    "title": "Let’s begin with a conversation.",
+    "subtitle": "Briefly tell me what brings you here and suggest two or three times that could work. This is not a live calendar; we will confirm the meeting personally.",
+    "form_title": "Request a first conversation",
+    "details": {
+      "session": "The first meeting is a full 55-minute session",
+      "format": "In Budapest or online",
+      "reply": "A reply usually within one business day"
+    }
   }
 }

--- a/client/src/i18n/locales/en/legal.json
+++ b/client/src/i18n/locales/en/legal.json
@@ -1,22 +1,21 @@
 {
   "terms": {
     "title": "Terms of Service",
-    "updated": "Last updated: September 27, 2025",
-    "intro": "These Terms of Service describe the conditions for receiving integral counselling sessions from Barna Karacsony. By booking or attending a session you confirm that you have read and accepted them.",
+    "updated": "Last updated: August 4, 2026",
+    "intro": "These Terms of Service describe the conditions for receiving integral counseling sessions from Barna Karácsony. By requesting or attending a session, you confirm that you have read and accepted them.",
     "sections": [
       {
         "title": "Scope of Services",
-        "body": "The practice offers integral counselling, which is a supportive, non-clinical method.",
+        "body": "I offer integral counseling, a supportive, non-clinical method.",
         "items": [
           "Sessions focus on personal development, self-awareness, and emotional support.",
           "The service does not replace psychotherapy, psychiatric treatment, or emergency care.",
-          "If a different level of care is required, you will be referred to an appropriate professional."
+          "If you need a different level of care, I will recommend that you contact an appropriate professional."
         ]
       },
       {
         "title": "Client Commitments",
         "items": [
-          "You must be at least 18 years old or provide written consent from a guardian.",
           "You agree to share information that is accurate to the best of your knowledge.",
           "You remain responsible for any decisions you make inside or outside the sessions."
         ]
@@ -33,76 +32,83 @@
         "title": "Confidentiality",
         "body": "All personal information shared in sessions is confidential and handled according to the Privacy Policy.",
         "items": [
-          "Confidentiality can be broken if there is a risk of serious harm to you or others.",
-          "Anonymous supervision may be used to improve professional quality."
+          "Confidentiality may be limited when required by law or when there is a serious and immediate risk of harm."
         ]
       },
       {
         "title": "Changes to These Terms",
         "items": [
-          "The practice may update these Terms when services or regulations change.",
+          "I may update these Terms when the service or applicable regulations change.",
           "Material changes will be communicated through the website or email."
         ]
       }
     ],
     "contact": {
       "title": "Questions or Concerns",
-      "body": "If you have any questions about these Terms, please contact Barna Karacsony at karacsony.barni@gmail.com or by phone at +36 70 572 8313."
+      "body": "If you have any questions about these Terms, please contact Barna Karácsony at karacsony.barni@gmail.com or by phone at +36 70 572 8313."
     }
   },
   "privacy": {
     "title": "Privacy Policy",
-    "updated": "Last updated: September 27, 2025",
-    "intro": "This Privacy Policy explains how Barna Karacsony collects, uses, and protects your personal data in connection with integral counselling services.",
+    "updated": "Last updated: August 4, 2026",
+    "intro": "This Privacy Policy explains how Barna Karácsony collects, uses, and protects your personal data when operating this website and providing integral counseling services.",
     "sections": [
       {
         "title": "Data Controller",
         "items": [
-          "Controller: Barna Karacsony, Budapest, Hungary.",
+          "Controller: Barna Karácsony, Budapest, Hungary.",
           "Contact: karacsony.barni@gmail.com, +36 70 572 8313."
         ]
       },
       {
         "title": "Personal Data We Collect",
         "items": [
-          "Contact details (name, email address, phone number).",
-          "Background information you share to tailor the sessions.",
-          "Scheduling information such as preferred times and session notes."
+          "The name, email address, optional phone number, and contact preference you enter in the form.",
+          "Information you voluntarily include in your message, such as the reason for contacting me and suitable meeting times.",
+          "Technical data and logs required by the hosting and form-delivery providers."
         ]
       },
       {
         "title": "Why We Process Your Data",
         "items": [
-          "To provide and customise counselling sessions.",
-          "To manage appointments, reminders, and follow-up communication.",
-          "To comply with legal obligations, including bookkeeping and safeguarding duties."
+          "To reply to your inquiry and arrange a meeting.",
+          "To provide counseling services if we begin working together.",
+          "To meet legal and administrative obligations related to the service."
         ]
       },
       {
         "title": "Legal Basis",
         "items": [
-          "Your consent given when you request or attend a session.",
-          "Our legitimate interest in delivering a safe and effective counselling service.",
-          "Compliance with legal requirements, where applicable."
+          "Taking steps at your request before a possible counseling engagement.",
+          "Your consent where it is required for information you voluntarily provide.",
+          "Compliance with legal obligations, where applicable."
+        ]
+      },
+      {
+        "title": "Technical Service Providers",
+        "items": [
+          "GitHub Pages hosts the website and GitHub may process technical data required to provide it.",
+          "Google Apps Script transfers form submissions, and Gmail delivers the details and message you provide.",
+          "These providers act according to their privacy terms and applicable data-protection safeguards."
         ]
       },
       {
         "title": "Data Retention",
         "items": [
-          "Session notes are stored securely and kept for a maximum of five years.",
-          "Administrative records required by law may be kept longer, then safely deleted."
+          "I keep inquiry data only as long as needed to arrange a meeting, support our work, or handle a related claim.",
+          "Administrative records that must be retained by law are kept for the required period and then deleted or securely destroyed."
         ]
       },
       {
         "title": "Your Rights",
         "items": [
           "You may request access to, correction of, or deletion of your personal data.",
-          "You may withdraw consent at any time, which may end the counselling relationship.",
+          "You may withdraw consent at any time where processing is based on consent.",
           "You may lodge a complaint with the Hungarian National Authority for Data Protection and Freedom of Information (NAIH)."
         ]
       }
     ],
-    "note": "The practice does not share your personal data with third parties unless required by law or with your explicit consent.",
+    "note": "Your personal data is handled only by the technical providers required to run the service, or disclosed when required by law or with your explicit consent.",
     "contact": {
       "title": "Privacy Questions",
       "body": "For privacy-related requests please email karacsony.barni@gmail.com. A response will be provided within 30 days."

--- a/client/src/i18n/locales/en/legal.json
+++ b/client/src/i18n/locales/en/legal.json
@@ -64,14 +64,14 @@
         "title": "Personal Data We Collect",
         "items": [
           "The name, email address, optional phone number, and contact preference you enter in the form.",
-          "Information you voluntarily include in your message, such as the reason for contacting me and suitable meeting times.",
+          "Information you voluntarily include in your message and the appointment time you select.",
           "Technical data and logs required by the hosting and form-delivery providers."
         ]
       },
       {
         "title": "Why We Process Your Data",
         "items": [
-          "To reply to your inquiry and arrange a meeting.",
+          "To reply to your inquiry, book an appointment, and send a calendar invitation.",
           "To provide counseling services if we begin working together.",
           "To meet legal and administrative obligations related to the service."
         ]
@@ -88,7 +88,8 @@
         "title": "Technical Service Providers",
         "items": [
           "GitHub Pages hosts the website and GitHub may process technical data required to provide it.",
-          "Google Apps Script transfers form submissions, and Gmail delivers the details and message you provide.",
+          "Google Apps Script transfers form submissions, checks Google Calendar availability, creates the booked event, and sends a calendar invitation; the website receives only free time slots and no event details.",
+          "Gmail delivers the notification containing the details and message you provide.",
           "These providers act according to their privacy terms and applicable data-protection safeguards."
         ]
       },

--- a/client/src/i18n/locales/en/nav.json
+++ b/client/src/i18n/locales/en/nav.json
@@ -10,5 +10,5 @@
   "close_menu": "Close navigation menu",
   "primary_navigation": "Primary navigation",
   "logo": "Barna Karácsony",
-  "tagline": "Integral Counselor Candidate"
+  "tagline": "Integral counselor in training"
 }

--- a/client/src/i18n/locales/en/services.json
+++ b/client/src/i18n/locales/en/services.json
@@ -22,7 +22,7 @@
   },
   "approach": {
     "eyebrow": "How I work",
-    "title": "I do not want to fix you. I want to help us see more clearly together.",
+    "title": "Together, we look from several angles to find a clearer picture.",
     "description": "An integral perspective looks beyond what you think about a situation. We also pay attention to what you feel, what your body signals, the relational and environmental forces around you, and what can be carried into everyday life.",
     "cta": "Request a first conversation",
     "principles": {
@@ -32,7 +32,7 @@
       },
       "understand": {
         "title": "Understand in context",
-        "description": "We do not look for one single cause; we consider inner experience, patterns, relationships, and environment together."
+        "description": "We consider inner experience, patterns, relationships, and environment together so the wider picture can emerge."
       },
       "move": {
         "title": "Find a step you can try",
@@ -46,7 +46,7 @@
     "steps": {
       "contact": {
         "title": "Let me know you would like to talk",
-        "description": "Use the form to briefly share what brings you here and which time would work for you."
+        "description": "Use the form to briefly share what brings you here and suggest two or three times that could work."
       },
       "first": {
         "title": "A first 55-minute session",

--- a/client/src/i18n/locales/hu/about.json
+++ b/client/src/i18n/locales/hu/about.json
@@ -4,7 +4,7 @@
   "lead": "Szoftverfejlesztőként összetett rendszerekkel dolgozom. Az Integrál Akadémia végzős hallgatójaként ugyanilyen kíváncsisággal fordulok az ember belső világa felé.",
   "story": {
     "systems": "A technológiai háttér megtanított pontosan kérdezni, összefüggéseket keresni és bonyolult helyzetekben is megtalálni a következő megtehető lépést. A tanácsadásban ezt a tisztaságot figyelmes, emberi jelenléttel kapcsolom össze.",
-    "integral": "Az integrál szemlélet azért áll közel hozzám, mert nem egyetlen magyarázatba próbálja bezárni az embert. Egyszerre figyel a gondolatokra, érzésekre, testre, kapcsolatokra és arra a tágabb közegre, amelyben élünk."
+    "integral": "Az integrál szemlélet egyszerre figyel a gondolatokra, érzésekre, testre, kapcsolatokra és arra a tágabb közegre, amelyben élünk. Ez a soknézőpontú megközelítés áll közel hozzám."
   },
   "facts": {
     "training": {

--- a/client/src/i18n/locales/hu/appointment.json
+++ b/client/src/i18n/locales/hu/appointment.json
@@ -1,11 +1,11 @@
 {
   "eyebrow": "Első lépés",
-  "title": "Válassz egy valóban szabad időpontot.",
-  "subtitle": "A naptár a Google Naptáram aktuális foglaltsága alapján mutat időpontokat. A kiválasztott alkalom a foglaláskor rögtön bekerül a naptárba.",
+  "title": "Válassz egy számodra megfelelő időpontot.",
+  "subtitle": "Foglalj kényelmesen az elérhető időpontok közül.",
   "details": {
     "duration": "Egy ülés 55 perc",
     "format": "Budapesten vagy online",
-    "calendar": "Élő Google Naptár-elérhetőség"
+    "calendar": "Azonnali visszaigazolás"
   },
   "form": {
     "title": "Időpontfoglalás",
@@ -32,19 +32,18 @@
   },
   "success": {
     "title": "Az időpontot lefoglaltad",
-    "description": "Az alkalom bekerült a Google Naptárba, a meghívót e-mailben is megkapod."
+    "description": "A meghívót e-mailben is megkapod."
   },
   "availability": {
-    "loading": "Szabad időpontok betöltése a Google Naptárból...",
-    "error": "A naptár elérhetősége most nem tölthető be. Próbáld újra, vagy írj közvetlenül e-mailt.",
+    "loading": "Szabad időpontok betöltése...",
+    "error": "A szabad időpontok most nem tölthetők be. Próbáld újra, vagy írj közvetlenül e-mailt.",
     "retry": "Újrapróbálom",
     "empty_title": "Jelenleg nincs foglalható időpont",
-    "empty_description": "Kérlek, írj e-mailt, és keresünk másik lehetőséget.",
-    "privacy": "Csak a szabad idősávok láthatók; a naptárbejegyzések címe és részletei nem kerülnek a weboldalra."
+    "empty_description": "Kérlek, írj e-mailt, és keresünk másik lehetőséget."
   },
   "conflict": {
     "title": "Ezt az időpontot közben lefoglalták",
-    "description": "Frissítettem a naptárt. Válassz egy másik szabad időpontot."
+    "description": "Frissítettem a szabad időpontokat. Válassz egy másikat."
   },
   "error": {
     "title": "Az időpontkérés nem lett elküldve",

--- a/client/src/i18n/locales/hu/appointment.json
+++ b/client/src/i18n/locales/hu/appointment.json
@@ -1,14 +1,14 @@
 {
   "eyebrow": "Első lépés",
-  "title": "Kezdjünk egy beszélgetéssel.",
-  "subtitle": "Nem kell hosszan bemutatnod a helyzetedet. Írd meg, mikor lenne jó találkozni, és általában egy munkanapon belül válaszolok.",
+  "title": "Válassz egy valóban szabad időpontot.",
+  "subtitle": "A naptár a Google Naptáram aktuális foglaltsága alapján mutat időpontokat. A kiválasztott alkalom a foglaláskor rögtön bekerül a naptárba.",
   "details": {
     "duration": "Egy ülés 55 perc",
     "format": "Budapesten vagy online",
-    "reply": "Válasz általában egy munkanapon belül"
+    "calendar": "Élő Google Naptár-elérhetőség"
   },
   "form": {
-    "title": "Mikor lenne jó találkozni?",
+    "title": "Időpontfoglalás",
     "name": "Teljes név",
     "name_placeholder": "Add meg a teljes neved",
     "email": "E-mail cím",
@@ -17,26 +17,38 @@
     "phone_placeholder": "+36 30 123 4567",
     "service": "Szolgáltatás",
     "service_placeholder": "Válassz szolgáltatást",
-    "date": "Előnyben részesített dátum",
+    "date": "Szabad dátum",
     "date_placeholder": "Válassz dátumot",
-    "time": "Előnyben részesített időpont",
+    "time": "Szabad időpont",
     "time_placeholder": "Válassz időpontot",
     "message": "További információ",
     "message_placeholder": "Amit érdemes tudnom előre...",
     "required": "kötelező",
-    "submit": "Első beszélgetés kérése",
-    "booking": "Kérés küldése..."
+    "submit": "Időpont lefoglalása",
+    "booking": "Foglalás..."
   },
   "services": {
     "individual": "Integrál tanácsadás (55 perc)"
   },
   "success": {
-    "title": "Időpontkérés elküldve",
-    "description": "Az időpontkérés sikeresen elküldve. Általában egy munkanapon belül jelentkezem."
+    "title": "Az időpontot lefoglaltad",
+    "description": "Az alkalom bekerült a Google Naptárba, a meghívót e-mailben is megkapod."
+  },
+  "availability": {
+    "loading": "Szabad időpontok betöltése a Google Naptárból...",
+    "error": "A naptár elérhetősége most nem tölthető be. Próbáld újra, vagy írj közvetlenül e-mailt.",
+    "retry": "Újrapróbálom",
+    "empty_title": "Jelenleg nincs foglalható időpont",
+    "empty_description": "Kérlek, írj e-mailt, és keresünk másik lehetőséget.",
+    "privacy": "Csak a szabad idősávok láthatók; a naptárbejegyzések címe és részletei nem kerülnek a weboldalra."
+  },
+  "conflict": {
+    "title": "Ezt az időpontot közben lefoglalták",
+    "description": "Frissítettem a naptárt. Válassz egy másik szabad időpontot."
   },
   "error": {
     "title": "Az időpontkérés nem lett elküldve",
-    "description": "Nem sikerült elküldeni a kérést. A megadott adatok megmaradtak, így újra próbálhatod, vagy közvetlenül kapcsolatba léphetsz velem.",
+    "description": "Nem sikerült lefoglalni az időpontot. A megadott adatok megmaradtak, így újra próbálhatod, vagy közvetlenül kapcsolatba léphetsz velem.",
     "email_action": "E-mail küldése ide: {{email}}"
   },
   "validation": {

--- a/client/src/i18n/locales/hu/appointment.json
+++ b/client/src/i18n/locales/hu/appointment.json
@@ -1,11 +1,11 @@
 {
   "eyebrow": "Első lépés",
   "title": "Kezdjünk egy beszélgetéssel.",
-  "subtitle": "Nem kell hosszan bemutatnod a helyzetedet. Írd meg, mikor lenne jó találkozni, és 24 órán belül válaszolok.",
+  "subtitle": "Nem kell hosszan bemutatnod a helyzetedet. Írd meg, mikor lenne jó találkozni, és általában egy munkanapon belül válaszolok.",
   "details": {
     "duration": "Egy ülés 55 perc",
     "format": "Budapesten vagy online",
-    "reply": "Válasz 24 órán belül"
+    "reply": "Válasz általában egy munkanapon belül"
   },
   "form": {
     "title": "Mikor lenne jó találkozni?",
@@ -32,7 +32,7 @@
   },
   "success": {
     "title": "Időpontkérés elküldve",
-    "description": "Az időpontkérés sikeresen elküldve. 24 órán belül jelentkezem."
+    "description": "Az időpontkérés sikeresen elküldve. Általában egy munkanapon belül jelentkezem."
   },
   "error": {
     "title": "Az időpontkérés nem lett elküldve",

--- a/client/src/i18n/locales/hu/contact.json
+++ b/client/src/i18n/locales/hu/contact.json
@@ -14,17 +14,17 @@
     "contact_method": "Előnyben részesített kapcsolatfelvételi mód",
     "contact_method_placeholder": "Hogyan szeretnéd, hogy kapcsolatba lépjek?",
     "message": "Üzenet",
-    "message_placeholder": "Oszd meg röviden a témát vagy a kérdéseidet...",
+    "message_placeholder": "Írd meg röviden, mi hoz, és adj meg két-három számodra megfelelő időpontot...",
     "required": "kötelező",
-    "submit": "Üzenet küldése",
+    "submit": "Első beszélgetés kérése",
     "sending": "Küldés..."
   },
   "success": {
-    "title": "Üzenet elküldve",
-    "description": "Az üzenet sikeresen elküldve. Köszönöm a megkeresést — 24 órán belül válaszolok."
+    "title": "Megkeresés elküldve",
+    "description": "Az üzenet sikeresen elküldve. Köszönöm a megkeresést — általában egy munkanapon belül válaszolok."
   },
   "error": {
-    "title": "Az üzenet nem lett elküldve",
+    "title": "A megkeresés nem lett elküldve",
     "description": "Nem sikerült elküldeni az üzenetet. A megadott adatok megmaradtak, így újra próbálhatod, vagy közvetlenül kapcsolatba léphetsz velem.",
     "email_action": "E-mail küldése ide: {{email}}"
   },
@@ -52,7 +52,7 @@
     "address_line2": "Magyarország",
     "hours": "Elérhetőség",
     "hours_by_appointment": "Hétköznap és hétvégén: egyeztetés szerint",
-    "response_time": "Válasz általában 24 órán belül"
+    "response_time": "Válasz általában egy munkanapon belül"
   },
   "emergency": {
     "title": "Sürgős segítségre van szükséged?",

--- a/client/src/i18n/locales/hu/home.json
+++ b/client/src/i18n/locales/hu/home.json
@@ -1,13 +1,13 @@
 {
   "hero": {
     "eyebrow": "Karácsony Barna · Integrál tanácsadó jelölt",
-    "title": "Értsd meg, mi történik benned. Indulj el afelé, ami valóban a tiéd.",
-    "subtitle": "Ha elakadtál egy döntésben, visszatérő mintákban vagy egyszerűen szeretnéd tisztábban látni önmagad, figyelmes és gyakorlatias teret kínálok a közös munkához.",
+    "title": "Tisztábban látni, amikor sok minden húz egyszerre.",
+    "subtitle": "Integrál tanácsadó jelöltként az elemző gondolkodást figyelmes, emberi jelenléttel kapcsolom össze. Döntésekkel, visszatérő mintákkal vagy túlterheltséggel is érkezhetsz.",
     "cta": "Így dolgozom",
     "appointment": "Első beszélgetést kérek",
     "profile_alt": "Karácsony Barna egy sárga fotelben ül",
-    "note": "Nem kész válaszokat adok. Abban segítek, hogy pontosabban lásd, mi történik — és mi lehet a következő valódi lépés.",
-    "note_label": "Közös figyelem, a te tempódban",
+    "note": "Szeretek pontos kérdéseket feltenni, összefüggéseket keresni, és nem siettetni azt, ami még nem állt össze.",
+    "note_label": "Tisztaság és emberi figyelem",
     "details": {
       "duration": "55 perces ülések",
       "format": "Budapesten vagy online",
@@ -15,9 +15,14 @@
     }
   },
   "contact_section": {
-    "eyebrow": "Kapcsolat",
-    "title": "Még van kérdésed, mielőtt időpontot kérnél?",
-    "subtitle": "Írj néhány sort, vagy keress közvetlenül telefonon és e-mailben.",
-    "form_title": "Írj nekem"
+    "eyebrow": "Első lépés",
+    "title": "Kezdjünk egy beszélgetéssel.",
+    "subtitle": "Írd meg röviden, mi hoz, és adj meg két-három számodra megfelelő időpontot. Az űrlap nem élő naptár: a találkozást személyesen egyeztetjük.",
+    "form_title": "Első beszélgetést kérek",
+    "details": {
+      "session": "Az első alkalom is teljes, 55 perces ülés",
+      "format": "Budapesten vagy online",
+      "reply": "Válasz általában egy munkanapon belül"
+    }
   }
 }

--- a/client/src/i18n/locales/hu/home.json
+++ b/client/src/i18n/locales/hu/home.json
@@ -17,7 +17,7 @@
   "contact_section": {
     "eyebrow": "Első lépés",
     "title": "Kezdjünk egy beszélgetéssel.",
-    "subtitle": "Írd meg röviden, mi hoz, és adj meg két-három számodra megfelelő időpontot. Az űrlap nem élő naptár: a találkozást személyesen egyeztetjük.",
+    "subtitle": "Válassz a Google Naptár alapján megjelenített, valóban szabad időpontok közül.",
     "form_title": "Első beszélgetést kérek",
     "details": {
       "session": "Az első alkalom is teljes, 55 perces ülés",

--- a/client/src/i18n/locales/hu/legal.json
+++ b/client/src/i18n/locales/hu/legal.json
@@ -64,14 +64,14 @@
         "title": "Milyen adatokat gyűjtünk",
         "items": [
           "Az űrlapon megadott név, e-mail cím, opcionális telefonszám és kapcsolattartási preferencia.",
-          "Az üzenetben önként megosztott információk, például a megkeresés témája és a számodra megfelelő időpontok.",
+          "Az üzenetben önként megosztott információk, valamint az általad kiválasztott foglalási időpont.",
           "A tárhely- és űrlapszolgáltatók működéséhez szükséges technikai adatok és naplóbejegyzések."
         ]
       },
       {
         "title": "Az adatkezelés céljai",
         "items": [
-          "Válaszadás a megkeresésedre és időpont egyeztetése.",
+          "Válaszadás a megkeresésedre, időpont foglalása és naptármeghívó küldése.",
           "A tanácsadási szolgáltatás biztosítása, ha együttműködés indul.",
           "A szolgáltatáshoz kapcsolódó jogi és adminisztratív kötelezettségek teljesítése."
         ]
@@ -88,7 +88,8 @@
         "title": "Technikai szolgáltatók",
         "items": [
           "A weboldalt a GitHub Pages szolgálja ki; a működéshez szükséges technikai adatokat a GitHub kezelheti.",
-          "Az űrlapbeküldéseket a Google Apps Script továbbítja, majd a Gmail kézbesíti a megadott adatokat és az üzenetet.",
+          "A Google Apps Script továbbítja az űrlapbeküldéseket, lekérdezi a Google Naptár foglaltságát, létrehozza a lefoglalt eseményt és naptármeghívót küld; a weboldal csak szabad idősávokat kap, eseményrészleteket nem.",
+          "A Gmail kézbesíti a megadott adatokat és az üzenetet tartalmazó értesítést.",
           "Ezek a szolgáltatók a saját adatvédelmi feltételeik és az alkalmazandó adatvédelmi garanciák szerint járnak el."
         ]
       },

--- a/client/src/i18n/locales/hu/legal.json
+++ b/client/src/i18n/locales/hu/legal.json
@@ -1,22 +1,21 @@
 {
   "terms": {
     "title": "Szolgáltatási feltételek",
-    "updated": "Utolsó frissítés: 2025. szeptember 27.",
-    "intro": "A szolgáltatási feltételek Barna Karácsony integrál tanácsadási üléseire vonatkoznak. Időpontfoglalással vagy részvétellel elfogadod az itt leírtakat.",
+    "updated": "Utolsó frissítés: 2026. augusztus 4.",
+    "intro": "A szolgáltatási feltételek Karácsony Barna integrál tanácsadási üléseire vonatkoznak. Időpontkéréssel vagy részvétellel elfogadod az itt leírtakat.",
     "sections": [
       {
         "title": "Szolgáltatás jellege",
-        "body": "A praxis integrál szemléletű tanácsadást nyújt, amely támogató, nem klinikai módszer.",
+        "body": "Integrál szemléletű tanácsadást nyújtok, amely támogató, nem klinikai módszer.",
         "items": [
           "Az ülések az önismeretre, személyes fejlődésre és érzelmi támogatásra koncentrálnak.",
           "A szolgáltatás nem helyettesíti a pszichoterápiát, pszichiátriai kezelést vagy sürgősségi ellátást.",
-          "Ha más szintű segítségre van szükség, megfelelő szakemberhez irányítunk."
+          "Ha más szintű segítségre van szükséged, javaslom, hogy megfelelő szakemberhez fordulj."
         ]
       },
       {
         "title": "Ügyfél kötelezettségei",
         "items": [
-          "A szolgáltatás igénybevételéhez 18 év felettinek kell lenned, vagy írásos szülői/gondviselői hozzájárulást kell bemutatnod.",
           "Vállalod, hogy a tudomásod szerinti valós adatokat osztod meg.",
           "A döntéseidért – akár az ülések alatt, akár azon kívül – továbbra is te felelsz."
         ]
@@ -33,14 +32,13 @@
         "title": "Titoktartás",
         "body": "A megosztott személyes adatok bizalmasak, kezelésükre az Adatkezelési tájékoztató vonatkozik.",
         "items": [
-          "A titoktartás csak akkor törhető meg, ha súlyos veszély fenyeget téged vagy másokat.",
-          "A szakmai minőség fejlesztése érdekében anonim szupervízió igénybe vehető."
+          "A titoktartás jogszabályi kötelezettség vagy súlyos, közvetlen veszély esetén korlátozható."
         ]
       },
       {
         "title": "Feltételek módosítása",
         "items": [
-          "A feltételek tartalma a szolgáltatás vagy a jogszabályok változása esetén frissülhet.",
+          "A feltételek tartalmát a szolgáltatás vagy a jogszabályok változása esetén frissíthetem.",
           "A lényeges változásokról a weboldalon vagy e-mailben kapsz tájékoztatást."
         ]
       }
@@ -52,57 +50,65 @@
   },
   "privacy": {
     "title": "Adatkezelési tájékoztató",
-    "updated": "Utolsó frissítés: 2025. szeptember 27.",
-    "intro": "Ez az adatkezelési tájékoztató ismerteti, hogyan gyűjti, használja és védi személyes adataidat Barna Karácsony az integrál tanácsadási szolgáltatás során.",
+    "updated": "Utolsó frissítés: 2026. augusztus 4.",
+    "intro": "Ez az adatkezelési tájékoztató ismerteti, hogyan gyűjti, használja és védi személyes adataidat Karácsony Barna a weboldal és az integrál tanácsadási szolgáltatás működtetése során.",
     "sections": [
       {
         "title": "Adatkezelő",
         "items": [
-          "Adatkezelő: Barna Karácsony, Budapest, Magyarország.",
+          "Adatkezelő: Karácsony Barna, Budapest, Magyarország.",
           "Kapcsolat: karacsony.barni@gmail.com, +36 70 572 8313."
         ]
       },
       {
         "title": "Milyen adatokat gyűjtünk",
         "items": [
-          "Kapcsolattartási adatok (név, e-mail cím, telefonszám).",
-          "Az ülésekre vonatkozó háttérinformációk, amelyeket a szolgáltatás személyre szabásához osztasz meg.",
-          "Időpontfoglalással kapcsolatos adatok, például preferált időpontok és ülésekről készült jegyzetek."
+          "Az űrlapon megadott név, e-mail cím, opcionális telefonszám és kapcsolattartási preferencia.",
+          "Az üzenetben önként megosztott információk, például a megkeresés témája és a számodra megfelelő időpontok.",
+          "A tárhely- és űrlapszolgáltatók működéséhez szükséges technikai adatok és naplóbejegyzések."
         ]
       },
       {
         "title": "Az adatkezelés céljai",
         "items": [
-          "A tanácsadási ülések biztosítása és személyre szabása.",
-          "Időpontok egyeztetése, emlékeztetők és utókövető kommunikáció kezelése.",
-          "Jogi kötelezettségek teljesítése, beleértve a nyilvántartási és megőrzési előírásokat."
+          "Válaszadás a megkeresésedre és időpont egyeztetése.",
+          "A tanácsadási szolgáltatás biztosítása, ha együttműködés indul.",
+          "A szolgáltatáshoz kapcsolódó jogi és adminisztratív kötelezettségek teljesítése."
         ]
       },
       {
         "title": "Jogi alap",
         "items": [
-          "Az általad adott hozzájárulás, amikor ülést kérsz vagy részt veszel rajta.",
-          "Jogos érdek a biztonságos és hatékony tanácsadás nyújtásához.",
+          "A kérésedre történő kapcsolatfelvétel és az esetleges együttműködést megelőző lépések megtétele.",
+          "A hozzájárulásod, amikor ez az általad önként megosztott adatok kezeléséhez szükséges.",
           "Jogszabályi kötelezettség teljesítése, amikor ez alkalmazandó."
+        ]
+      },
+      {
+        "title": "Technikai szolgáltatók",
+        "items": [
+          "A weboldalt a GitHub Pages szolgálja ki; a működéshez szükséges technikai adatokat a GitHub kezelheti.",
+          "Az űrlapbeküldéseket a Google Apps Script továbbítja, majd a Gmail kézbesíti a megadott adatokat és az üzenetet.",
+          "Ezek a szolgáltatók a saját adatvédelmi feltételeik és az alkalmazandó adatvédelmi garanciák szerint járnak el."
         ]
       },
       {
         "title": "Adatmegőrzés",
         "items": [
-          "Az ülésjegyzeteket biztonságosan tároljuk, legfeljebb öt évig őrizzük, majd töröljük.",
-          "A jogszabály által előírt adminisztratív iratokat hosszabb ideig kell megőrizni, ezután biztonságosan megsemmisítjük."
+          "A megkeresés adatait addig őrzöm, amíg az egyeztetéshez, az együttműködéshez vagy egy kapcsolódó igény kezeléséhez szükséges.",
+          "A jogszabály alapján megőrzendő adminisztratív iratokat a kötelező időtartam végéig őrzöm, majd törlöm vagy biztonságosan megsemmisítem."
         ]
       },
       {
         "title": "Jogosultságaid",
         "items": [
           "Kérheted személyes adataid hozzáférését, helyesbítését vagy törlését.",
-          "Bármikor visszavonhatod a hozzájárulásodat, ami a tanácsadási kapcsolat megszűnését eredményezheti.",
+          "A hozzájáruláson alapuló adatkezeléshez adott hozzájárulásodat bármikor visszavonhatod.",
           "Panaszt tehetsz a Nemzeti Adatvédelmi és Információszabadság Hatóságnál (NAIH)."
         ]
       }
     ],
-    "note": "Személyes adataidat nem adjuk át harmadik félnek, kivéve ha azt jogszabály írja elő vagy ahhoz kifejezetten hozzájárulsz.",
+    "note": "Személyes adataidat csak a szolgáltatás működéséhez szükséges technikai szolgáltatók kezelik, illetve akkor adom át, ha azt jogszabály írja elő vagy ahhoz kifejezetten hozzájárulsz.",
     "contact": {
       "title": "Adatkezeléssel kapcsolatos megkeresések",
       "body": "Adatvédelmi ügyekben a karacsony.barni@gmail.com címen kereshetsz. A megkeresésekre 30 napon belül válasz érkezik."

--- a/client/src/i18n/locales/hu/services.json
+++ b/client/src/i18n/locales/hu/services.json
@@ -22,7 +22,7 @@
   },
   "approach": {
     "eyebrow": "Hogyan dolgozom",
-    "title": "Nem megjavítani szeretnélek, hanem veled együtt pontosabban látni.",
+    "title": "Veled együtt, több nézőpontból keresünk tisztább képet.",
     "description": "Az integrál szemléletben nem csak azt nézzük, mit gondolsz egy helyzetről. Figyelünk arra is, mit érzel, mit jelez a tested, milyen kapcsolati és környezeti hatások vesznek körül, és mi vihető át mindebből a hétköznapokba.",
     "cta": "Első beszélgetést kérek",
     "principles": {
@@ -32,7 +32,7 @@
       },
       "understand": {
         "title": "Összefüggéseiben érteni",
-        "description": "Nem egyetlen okot keresünk: együtt nézzük a belső élményt, a mintákat, a kapcsolatokat és a környezetet."
+        "description": "Együtt nézzük a belső élményt, a mintákat, a kapcsolatokat és a környezetet, hogy összeálljon a tágabb kép."
       },
       "move": {
         "title": "Kipróbálható lépést találni",
@@ -46,7 +46,7 @@
     "steps": {
       "contact": {
         "title": "Jelzed, hogy beszélnél",
-        "description": "Az űrlapon röviden megírhatod, mi hoz, és melyik időpont lenne megfelelő."
+        "description": "Az űrlapon röviden megírhatod, mi hoz, és javasolhatsz két-három megfelelő időpontot."
       },
       "first": {
         "title": "Első, 55 perces ülés",

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -229,7 +229,6 @@
 
   #about,
   #services,
-  #appointment-booking,
   #contact {
     scroll-margin-top: 5.5rem;
   }

--- a/client/src/lib/calendarAvailability.ts
+++ b/client/src/lib/calendarAvailability.ts
@@ -1,0 +1,103 @@
+import { APPS_SCRIPT_WEB_APP_URL } from "@/lib/formSubmission";
+
+const APPS_SCRIPT_MESSAGE_SOURCE = "integral-counseling-apps-script";
+const APPS_SCRIPT_TIMEOUT_MS = 15000;
+
+interface AvailabilityMessage {
+  source?: string;
+  ok?: boolean;
+  error?: string;
+  requestId?: string;
+  slots?: string[];
+  timeZone?: string;
+}
+
+export interface CalendarAvailability {
+  slots: string[];
+  timeZone: string;
+}
+
+export async function getCalendarAvailability(): Promise<CalendarAvailability> {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    throw new Error("Calendar availability requires a browser environment.");
+  }
+
+  const requestId = `availability_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+  const iframe = document.createElement("iframe");
+  const url = new URL(APPS_SCRIPT_WEB_APP_URL);
+
+  url.searchParams.set("action", "availability");
+  url.searchParams.set("origin", window.location.origin);
+  url.searchParams.set("requestId", requestId);
+
+  iframe.src = url.toString();
+  iframe.style.display = "none";
+  iframe.title = "";
+
+  return new Promise<CalendarAvailability>((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = () => {
+      window.removeEventListener("message", handleMessage);
+      window.clearTimeout(timeoutId);
+      iframe.remove();
+    };
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      callback();
+    };
+
+    const handleMessage = (event: MessageEvent<AvailabilityMessage>) => {
+      if (!isTrustedAppsScriptOrigin(event.origin)) {
+        return;
+      }
+
+      const message = event.data;
+      if (
+        !message ||
+        message.source !== APPS_SCRIPT_MESSAGE_SOURCE ||
+        message.requestId !== requestId
+      ) {
+        return;
+      }
+
+      if (!message.ok) {
+        finish(() => reject(new Error(message.error || "Could not load calendar availability.")));
+        return;
+      }
+
+      finish(() =>
+        resolve({
+          slots: Array.isArray(message.slots) ? message.slots : [],
+          timeZone: message.timeZone || "Europe/Budapest",
+        }),
+      );
+    };
+
+    const timeoutId = window.setTimeout(() => {
+      finish(() => reject(new Error("Timed out while loading calendar availability.")));
+    }, APPS_SCRIPT_TIMEOUT_MS);
+
+    window.addEventListener("message", handleMessage);
+    document.body.appendChild(iframe);
+  });
+}
+
+function isTrustedAppsScriptOrigin(origin: string) {
+  try {
+    const { protocol, host } = new URL(origin);
+    return (
+      protocol === "https:" &&
+      (host === "script.google.com" ||
+        host === "script.googleusercontent.com" ||
+        host.endsWith(".googleusercontent.com"))
+    );
+  } catch {
+    return false;
+  }
+}

--- a/client/src/lib/formSubmission.ts
+++ b/client/src/lib/formSubmission.ts
@@ -1,6 +1,6 @@
 const DEFAULT_APPS_SCRIPT_WEB_APP_URL =
   "https://script.google.com/macros/s/AKfycbztbd9BZ55jNSTu4TIGgwk4mvIHteoyPhiB_qbzvRl4MM7T5XYq1axQNxhbudFutvht/exec";
-const APPS_SCRIPT_WEB_APP_URL =
+export const APPS_SCRIPT_WEB_APP_URL =
   import.meta.env.VITE_APPS_SCRIPT_WEB_APP_URL?.trim() ||
   DEFAULT_APPS_SCRIPT_WEB_APP_URL;
 const APPS_SCRIPT_MESSAGE_SOURCE = "integral-counseling-apps-script";
@@ -20,6 +20,7 @@ interface WebsiteFormPayload {
   preferredDate?: string;
   preferredDateLabel?: string;
   preferredTime?: string;
+  slotStart?: string;
   startedAt: number;
   website?: string;
 }
@@ -29,7 +30,18 @@ interface AppsScriptMessage {
   ok?: boolean;
   ignored?: boolean;
   error?: string;
+  errorCode?: string;
   requestId?: string;
+}
+
+export class WebsiteFormSubmissionError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "WebsiteFormSubmissionError";
+  }
 }
 
 export async function submitWebsiteForm(payload: WebsiteFormPayload) {
@@ -124,10 +136,11 @@ async function submitToAppsScript(payload: WebsiteFormPayload) {
       }
 
       rejectOnce(
-        new Error(
+        new WebsiteFormSubmissionError(
           message.ignored
             ? "Apps Script ignored the submission as suspected spam."
             : message.error || "Apps Script rejected the submission.",
+          message.errorCode,
         ),
       );
     };

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import About from "@/components/About";
 import Services from "@/components/Services";
-import Contact from "@/components/Contact";
+import AppointmentBooking from "@/components/AppointmentBooking";
 import Footer from "@/components/Footer";
 import { consumePendingScrollTarget, scrollToSection } from "@/lib/routing";
 
@@ -31,7 +31,7 @@ export default function Home() {
           <Services />
         </div>
         <div id="contact">
-          <Contact />
+          <AppointmentBooking />
         </div>
       </main>
       <Footer />

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -3,7 +3,6 @@ import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import About from "@/components/About";
 import Services from "@/components/Services";
-import AppointmentBooking from "@/components/AppointmentBooking";
 import Contact from "@/components/Contact";
 import Footer from "@/components/Footer";
 import { consumePendingScrollTarget, scrollToSection } from "@/lib/routing";
@@ -30,9 +29,6 @@ export default function Home() {
         </div>
         <div id="services">
           <Services />
-        </div>
-        <div id="appointment-booking">
-          <AppointmentBooking />
         </div>
         <div id="contact">
           <Contact />

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -31,7 +31,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json({ 
         success: true, 
-        message: "Thank you for reaching out. I'll get back to you within 24 hours.",
+        message: "Thank you for reaching out. I usually reply within one business day.",
         inquiryId: inquiry.id
       });
     } catch (error) {
@@ -76,7 +76,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json({ 
         success: true, 
-        message: "Your appointment request has been received. I'll contact you within 24 hours to confirm.",
+        message: "Your appointment request has been received. I’ll usually contact you within one business day to confirm.",
         appointmentId: appointment.id
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

- make the Hungarian and English copy more distinctly Barni and reduce repeated negative constructions
- replace “Integral Counselor Candidate” with “integral counselor in training” in English
- replace the locally generated date/time list with live availability
- keep the booking text focused on the visitor instead of explaining calendar internals
- expose only free start times; private event titles and details never reach the website
- recheck the chosen slot under a server-side lock to prevent simultaneous double-booking
- create a 55-minute calendar event and send the visitor an invitation after booking
- route every first-conversation CTA to the single booking journey
- correct unsupported legal boilerplate and document the actual GitHub Pages and form-service data flow
- document the Apps Script project, production web-app, and versioned library URLs
- leave the visible email address unchanged, as requested

## Live calendar configuration

Apps Script deployment Version 3 is deployed and authorized at the existing production URL.

- appointment starts every day, including weekends
- starts from 09:00 through 20:00 in Europe/Budapest
- 55-minute sessions, with starts every 30 minutes
- at least 24 hours’ notice
- the next 14 dates with availability, within a 60-day horizon
- events marked Busy remove every overlapping appointment
- events explicitly marked Available do not block appointment times
- the Apps Script owner’s primary Google Calendar is used

## Validation

- `npm run check`
- `npm run build`
- JSON parsing for changed locale and manifest files
- Apps Script syntax check
- mocked weekend, 20:00, busy-overlap, and transparent-event checks
- deployed endpoint returned 269 current slots
- deployed endpoint included Saturday, Sunday, and 20:00 starts
- rendered desktop and 390 px mobile UI checks from the earlier booking implementation
- interaction check: selecting a time enables booking; changing the date clears the old time and refreshes the options
- `git diff --check`

## Facts still needed

The repository and saved project context do not establish the session fee, Budapest district, online meeting platform, adult-only scope, or current supervision arrangement. These were not guessed.

The revised legal/privacy copy is a factual cleanup of the current implementation, not a substitute for review by a Hungarian GDPR professional.