### PR TITLE
Fix live calendar availability loading

### DIFF
--- a/APPS_SCRIPT_SETUP.md
+++ b/APPS_SCRIPT_SETUP.md
@@ -6,7 +6,7 @@ This repository is configured to keep the website on GitHub Pages and send form 
 
 - Project editor: https://script.google.com/home/projects/1qHNojJ5rFOp0avlvqYrER06mX78zNrqIuQ4bKBFjz5dmnca5yc9L3Qnr/edit
 - Production web app: https://script.google.com/macros/s/AKfycbztbd9BZ55jNSTu4TIGgwk4mvIHteoyPhiB_qbzvRl4MM7T5XYq1axQNxhbudFutvht/exec
-- Version 3 library: https://script.google.com/macros/library/d/1qHNojJ5rFOp0avlvqYrER06mX78zNrqIuQ4bKBFjz5dmnca5yc9L3Qnr/3
+- Version 4 library: https://script.google.com/macros/library/d/1qHNojJ5rFOp0avlvqYrER06mX78zNrqIuQ4bKBFjz5dmnca5yc9L3Qnr/4
 
 ## What this does
 

--- a/client/src/lib/calendarAvailability.ts
+++ b/client/src/lib/calendarAvailability.ts
@@ -1,6 +1,5 @@
 import { APPS_SCRIPT_WEB_APP_URL } from "@/lib/formSubmission";
 
-const APPS_SCRIPT_MESSAGE_SOURCE = "integral-counseling-apps-script";
 const APPS_SCRIPT_TIMEOUT_MS = 15000;
 
 interface AvailabilityMessage {
@@ -23,24 +22,25 @@ export async function getCalendarAvailability(): Promise<CalendarAvailability> {
   }
 
   const requestId = `availability_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
-  const iframe = document.createElement("iframe");
+  const callbackName = `integralCalendarAvailability_${requestId}`;
+  const callbacks = window as unknown as Record<
+    string,
+    ((message: AvailabilityMessage) => void) | undefined
+  >;
+  const script = document.createElement("script");
   const url = new URL(APPS_SCRIPT_WEB_APP_URL);
 
   url.searchParams.set("action", "availability");
-  url.searchParams.set("origin", window.location.origin);
   url.searchParams.set("requestId", requestId);
-
-  iframe.src = url.toString();
-  iframe.style.display = "none";
-  iframe.title = "";
+  url.searchParams.set("callback", callbackName);
 
   return new Promise<CalendarAvailability>((resolve, reject) => {
     let settled = false;
 
     const cleanup = () => {
-      window.removeEventListener("message", handleMessage);
       window.clearTimeout(timeoutId);
-      iframe.remove();
+      script.remove();
+      delete callbacks[callbackName];
     };
 
     const finish = (callback: () => void) => {
@@ -52,15 +52,9 @@ export async function getCalendarAvailability(): Promise<CalendarAvailability> {
       callback();
     };
 
-    const handleMessage = (event: MessageEvent<AvailabilityMessage>) => {
-      if (!isTrustedAppsScriptOrigin(event.origin)) {
-        return;
-      }
-
-      const message = event.data;
+    callbacks[callbackName] = (message: AvailabilityMessage) => {
       if (
         !message ||
-        message.source !== APPS_SCRIPT_MESSAGE_SOURCE ||
         message.requestId !== requestId
       ) {
         return;
@@ -79,25 +73,16 @@ export async function getCalendarAvailability(): Promise<CalendarAvailability> {
       );
     };
 
+    script.onerror = () => {
+      finish(() => reject(new Error("Could not load calendar availability.")));
+    };
+
     const timeoutId = window.setTimeout(() => {
       finish(() => reject(new Error("Timed out while loading calendar availability.")));
     }, APPS_SCRIPT_TIMEOUT_MS);
 
-    window.addEventListener("message", handleMessage);
-    document.body.appendChild(iframe);
+    script.src = url.toString();
+    script.async = true;
+    document.head.appendChild(script);
   });
-}
-
-function isTrustedAppsScriptOrigin(origin: string) {
-  try {
-    const { protocol, host } = new URL(origin);
-    return (
-      protocol === "https:" &&
-      (host === "script.google.com" ||
-        host === "script.googleusercontent.com" ||
-        host.endsWith(".googleusercontent.com"))
-    );
-  } catch {
-    return false;
-  }
 }


### PR DESCRIPTION
## Summary

- replace the blocked cross-origin availability iframe with Google Apps Script’s supported read-only JSONP response
- keep returning only free start times; no calendar event details are exposed
- update the documented versioned Apps Script library URL to Version 4

## Deployment

Apps Script Version 4 is deployed at the existing production web-app URL.

## Validation

- `npm run check`
- `npm run build`
- Apps Script syntax and JSONP response checks
- mocked weekend, 20:00, busy-overlap, and transparent-event checks
- reproduced the iframe timeout on production before the fix
- verified production now loads 14 real dates without its error state
- verified Saturday and Sunday dates are shown
- verified Sunday 20:00 can be selected
- verified selecting a time enables the booking button
- verified Hungarian and English booking copy