### PR TITLE
Clean up repository instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ Strict TypeScript is enforced; keep `npm run check` clean before committing. Use
 ## Commit & Pull Request Guidelines
 History favors concise imperative subjects (for example "Improve email sending functionality with detailed error logging"); follow that pattern and isolate logical changes per commit. PRs should include a short summary, screenshots or logs for user-facing work, notes on environment variables, and the tests you ran. Seek review before merge and keep future CI checks green.
 
+Whenever you merge a pull request, automatically delete its remote source branch and remove any clean local branch and worktree for that source branch. Do not delete `main`, protected branches, branches or worktrees with uncommitted changes, or a branch the user explicitly asked to preserve.
+
 ## Additional Project Notes
 - Header navigation uses Wouter; scroll actions set a `pending-scroll-target` key in `sessionStorage` before navigating home, so reuse `handleScrollNavigation` when adding new in-page anchors.
 - Terms and Privacy pages live in the `legal` i18n namespace; new legal copy must update `client/src/i18n/locales/{lang}/legal.json` and register imports in `client/src/i18n/index.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,19 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-The Vite + Express monorepo is split into `client/`, `server/`, and `shared/`. React code lives in `client/src` with feature folders (`components/`, `pages/`, `hooks/`, `lib/`, `i18n/`, `types/`); `@/` resolves to this tree. Re-use types and Drizzle tables from `shared/schema.ts` through `@shared/`. Express boots from `server/index.ts`, wiring routes, email helpers, storage, and Vite dev middleware. Leave generated assets under `attached_assets/` untouched.
+React code lives in `client/src` with feature folders (`components/`, `pages/`, `hooks/`, `lib/`, `i18n/`, `types/`); `@/` resolves to this tree.
 
 ## Build, Test & Development Commands
 - `npm install` — install dependencies once per machine.
-- `npm run dev` — start Express via `tsx`; Vite middleware serves the client.
-- `npm run build` — run `vite build` then bundle `server/index.ts` to `dist/`.
-- `npm run start` — execute the bundled server with `NODE_ENV=production`.
 - `npm run check` — TypeScript project check with no emit.
-- `npm run db:push` — sync `shared/schema.ts` to Postgres through Drizzle.
 
 ## Coding Style & Naming Conventions
 Strict TypeScript is enforced; keep `npm run check` clean before committing. Use two-space indentation and double-quoted imports to match existing files. React components and pages stay PascalCase, hooks follow `use-*`, and shared utilities live in `client/src/lib`. Favor Tailwind utilities, extending tokens in `tailwind.config.ts` instead of adding bespoke CSS.
 
-## Testing Guidelines
-No automated runner ships yet, so document manual checks (contact form, appointment booking, `/en` toggle) in every PR. When introducing automation, use `vitest` with React Testing Library for the client and `supertest` for Express routes, storing specs in `client/src/__tests__` or `server/__tests__`. Update `tsconfig.json` includes if `*.test.ts[x]` files are added.
-
 ## Commit & Pull Request Guidelines
 History favors concise imperative subjects (for example "Improve email sending functionality with detailed error logging"); follow that pattern and isolate logical changes per commit. PRs should include a short summary, screenshots or logs for user-facing work, notes on environment variables, and the tests you ran. Seek review before merge and keep future CI checks green.
 
-After merging a pull request, automatically delete its source branch from the remote and remove the corresponding local branch and worktree after confirming they contain no uncommitted changes. Do not delete protected branches such as `main`.
-
-## Environment & Configuration
-Provide a `.env` with `DATABASE_URL`, `SENDGRID_API_KEY`, and optionally `PORT`. `drizzle.config.ts` requires `DATABASE_URL` even during builds; run `npm run db:push` after editing `shared/schema.ts`. Outbound email currently uses `karacsony.barni@gmail.com`; change `server/email.ts` if ownership shifts. Avoid logging secrets by using the logger in `server/vite.ts`.
-
-## General Learnings
-- Shell commands run through PowerShell, so classic Unix helpers like `sed` or `awk` may be unavailable; fall back to `pwsh` cmdlets, Node, or Python for file inspection.
-- Multi-line snippets should use PowerShell here-strings (e.g., `@'... '@` with `Set-Content`); heredocs like `cat <<'PY'` are parsed by PowerShell and fail.
-- `python -c` quoting is brittle under PowerShell because double quotes terminate the command and backslashes are literal; prefer temporary script files or wrap the code in double quotes while using single quotes inside.
-- For quick replacements, `(Get-Content -Raw path).Replace(needle, replacement) | Set-Content` reliably preserves Windows newlines.
-- `Select-String` treats patterns as regex by default; add `-SimpleMatch` when the search text contains quotes or other regex metacharacters.
-
 ## Additional Project Notes
 - Header navigation uses Wouter; scroll actions set a `pending-scroll-target` key in `sessionStorage` before navigating home, so reuse `handleScrollNavigation` when adding new in-page anchors.
-- `Home` page reads that key in a `useEffect` and smooth-scrolls to matching element IDs; keep section wrappers on `about`, `services`, `appointment-booking`, `contact` in sync with nav targets.
 - Terms and Privacy pages live in the `legal` i18n namespace; new legal copy must update `client/src/i18n/locales/{lang}/legal.json` and register imports in `client/src/i18n/index.ts`.
 - Terms/Privacy mount effects call `window.scrollTo({ top: 0, behavior: "auto" })` to reset position; mirror this for future standalone routes.
-- Language-sensitive routing expects both `/path` and `/en/path` entries in `client/src/App.tsx`, and `getHref` in `Header` prepends `/en` when English is active.
-- `npm run check` currently fails because `serviceType` is missing on payload types in `server/routes.ts` and `server/storage.ts`; fix before relying on the TypeScript gate.
-
-## Replit & Runtime Notes
-- `.replit` ensures deps are installed before dev: `npm install --no-audit --no-fund && npm run dev`. If `cross-env: not found` appears, re-run install.
-- `cross-env` is in `dependencies` so `NODE_ENV` is available in both dev and production. Do not move it back to `devDependencies`.
-- Rollup: use cross-platform `rollup` package. Do not add `@rollup/rollup-win32-x64-msvc`; it breaks installs on Linux (Replit).
-- Dev: `npm run dev` runs `tsx server/index.ts` with `NODE_ENV=development`. Vite middleware only loads when `NODE_ENV=development` in `server/index.ts`.
-- Prod: `npm run build` creates `dist/index.js`; `npm run start` uses `NODE_ENV=production` to serve static files. Keep `.replit [deployment]` steps in sync.
-- Ports: server binds `0.0.0.0` on `process.env.PORT || 5000`. `.replit` sets `PORT=5000` and maps external ports accordingly.
-- Environment: PowerShell-based shell on Replit; prefer `pwsh`-friendly commands as noted in General Learnings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ No automated runner ships yet, so document manual checks (contact form, appointm
 ## Commit & Pull Request Guidelines
 History favors concise imperative subjects (for example "Improve email sending functionality with detailed error logging"); follow that pattern and isolate logical changes per commit. PRs should include a short summary, screenshots or logs for user-facing work, notes on environment variables, and the tests you ran. Seek review before merge and keep future CI checks green.
 
+After merging a pull request, automatically delete its source branch from the remote and remove the corresponding local branch and worktree after confirming they contain no uncommitted changes. Do not delete protected branches such as `main`.
+
 ## Environment & Configuration
 Provide a `.env` with `DATABASE_URL`, `SENDGRID_API_KEY`, and optionally `PORT`. `drizzle.config.ts` requires `DATABASE_URL` even during builds; run `npm run db:push` after editing `shared/schema.ts`. Outbound email currently uses `karacsony.barni@gmail.com`; change `server/email.ts` if ownership shifts. Avoid logging secrets by using the logger in `server/vite.ts`.
 


### PR DESCRIPTION
## Summary

- remove stale Express runtime, database, SendGrid, PowerShell, and Replit guidance
- remove obsolete generated-asset, navigation-anchor, and TypeScript-failure instructions
- retain only verified project-specific structure, style, PR, routing, and localization guidance
- require automatic source-branch and clean local-worktree deletion whenever a PR is merged

## Verification

- npm run check
- git diff --check