### PR TITLE
Increase Apps Script timeouts

### DIFF
--- a/client/src/lib/calendarAvailability.ts
+++ b/client/src/lib/calendarAvailability.ts
@@ -1,6 +1,6 @@
 import { APPS_SCRIPT_WEB_APP_URL } from "@/lib/formSubmission";
 
-const APPS_SCRIPT_TIMEOUT_MS = 15000;
+const APPS_SCRIPT_TIMEOUT_MS = 60000;
 
 interface AvailabilityMessage {
   source?: string;

--- a/client/src/lib/formSubmission.ts
+++ b/client/src/lib/formSubmission.ts
@@ -4,7 +4,7 @@ export const APPS_SCRIPT_WEB_APP_URL =
   import.meta.env.VITE_APPS_SCRIPT_WEB_APP_URL?.trim() ||
   DEFAULT_APPS_SCRIPT_WEB_APP_URL;
 const APPS_SCRIPT_MESSAGE_SOURCE = "integral-counseling-apps-script";
-const APPS_SCRIPT_TIMEOUT_MS = 15000;
+const APPS_SCRIPT_TIMEOUT_MS = 60000;
 
 type FormType = "appointment" | "contact";
 


### PR DESCRIPTION
## Summary

- increase live calendar availability loading timeout from 15 to 60 seconds
- increase appointment and contact form submission timeout from 15 to 60 seconds

## Why

Google Apps Script cold starts and calendar reads can exceed 15 seconds, causing a false unavailable state even though the endpoint eventually succeeds.

## Validation

- `npm run check`
- `npm run build`
- `git diff --check`
- verified the new production asset is deployed
- reproduced a live cold calendar response that took longer than the old 15-second limit
- confirmed it completed within the new timeout without showing the error state
- confirmed weekend dates and 20:00 appointments still appear