### PR TITLE
Document Apps Script Version 5

### DIFF
--- a/APPS_SCRIPT_SETUP.md
+++ b/APPS_SCRIPT_SETUP.md
@@ -6,7 +6,7 @@ This repository is configured to keep the website on GitHub Pages and send form 
 
 - Project editor: https://script.google.com/home/projects/1qHNojJ5rFOp0avlvqYrER06mX78zNrqIuQ4bKBFjz5dmnca5yc9L3Qnr/edit
 - Production web app: https://script.google.com/macros/s/AKfycbztbd9BZ55jNSTu4TIGgwk4mvIHteoyPhiB_qbzvRl4MM7T5XYq1axQNxhbudFutvht/exec
-- Version 4 library: https://script.google.com/macros/library/d/1qHNojJ5rFOp0avlvqYrER06mX78zNrqIuQ4bKBFjz5dmnca5yc9L3Qnr/4
+- Version 5 library: https://script.google.com/macros/library/d/1qHNojJ5rFOp0avlvqYrER06mX78zNrqIuQ4bKBFjz5dmnca5yc9L3Qnr/5
 
 ## What this does
 


### PR DESCRIPTION
## Summary
- update the documented Apps Script library URL from Version 4 to Version 5
- Version 5 adds a one-hour server-side availability cache
- successful website bookings invalidate the availability cache immediately
- booking validation still reads Google Calendar live to prevent conflicts

## Verification
- cache behavior covered with isolated Apps Script mocks
- Apps Script syntax check passed
- `npm run check`
- `npm run build`
- production availability reload verified after deployment