### PR TITLE
Clarify counseling process copy

### DIFF
--- a/client/src/i18n/locales/en/services.json
+++ b/client/src/i18n/locales/en/services.json
@@ -16,8 +16,8 @@
       "description": "Things look fine from the outside, while tension, exhaustion, or distance from how you want to live is growing within."
     },
     "values": {
-      "title": "Your earlier goals no longer provide enough direction",
-      "description": "There may be no crisis. What matters to you is changing, and you want to understand what is taking shape where the old answers used to be."
+      "title": "Your earlier goals no longer show you what comes next",
+      "description": "There may be no crisis. What used to motivate and guide you no longer fully fits what matters to you now. You want to see more clearly what is taking shape in its place."
     }
   },
   "approach": {
@@ -45,16 +45,16 @@
     "title": "We start simply",
     "steps": {
       "contact": {
-        "title": "Choose an available time",
-        "description": "Select one of the times shown, enter your contact details, and receive the invitation by email."
+        "title": "Book your first session",
+        "description": "Choose from the available times shown. After booking, you receive the calendar invitation by email."
       },
       "first": {
         "title": "A first 55-minute session",
-        "description": "We get to know each other, explore your situation, and consider what direction could be useful."
+        "description": "We get to know each other, explore what brought you here, and clarify together what you want to understand or change and what the focus of our work should be."
       },
       "continue": {
-        "title": "A direction we shape together",
-        "description": "If the meeting feels like a good foundation to both of us, we continue around your goals and at a pace that fits you."
+        "title": "We agree on how to work together",
+        "description": "If we both feel it makes sense to continue, we agree on the focus of the work, meeting every one or two weeks, and the other important boundaries of our collaboration."
       }
     }
   }

--- a/client/src/i18n/locales/hu/services.json
+++ b/client/src/i18n/locales/hu/services.json
@@ -16,8 +16,8 @@
       "description": "Kívülről rendben vannak a dolgok, belül viszont nő a feszültség, a kimerültség vagy a távolság attól, ahogyan élni szeretnél."
     },
     "values": {
-      "title": "A korábbi céljaid már nem adnak elég irányt",
-      "description": "Nem feltétlenül van krízis. Változik, mi fontos számodra, és szeretnéd megérteni, mi formálódik a régi válaszok helyén."
+      "title": "A korábbi céljaid már nem mutatják, merre tovább",
+      "description": "Nem feltétlenül van krízis. Ami eddig motivált és irányt adott, már nem illeszkedik teljesen ahhoz, ami most fontos neked. Szeretnéd tisztábban látni, mi formálódik a helyén."
     }
   },
   "approach": {
@@ -45,16 +45,16 @@
     "title": "Egyszerűen kezdünk",
     "steps": {
       "contact": {
-        "title": "Kiválasztasz egy szabad időpontot",
-        "description": "A megjelenő időpontok közül választasz, megadod az elérhetőségedet, majd e-mailben megkapod a meghívót."
+        "title": "Lefoglalod az első alkalmat",
+        "description": "Választhatsz a megjelenő szabad időpontok közül. A foglalás után e-mailben megkapod a naptármeghívót."
       },
       "first": {
         "title": "Első, 55 perces ülés",
-        "description": "Megismerjük egymást, körbejárjuk a helyzetedet, és megnézzük, milyen irány lenne hasznos."
+        "description": "Megismerjük egymást, körbejárjuk, mi hozott, és közösen pontosítjuk, mit szeretnél jobban érteni vagy megváltoztatni, illetve mi legyen a közös munka fókusza."
       },
       "continue": {
-        "title": "Közösen kialakított irány",
-        "description": "Ha mindketten jó alapnak érezzük a találkozást, a te céljaidhoz és ritmusodhoz igazodva folytatjuk."
+        "title": "Kialakítjuk a közös munka kereteit",
+        "description": "Ha mindketten úgy látjuk, hogy érdemes folytatni, közösen megállapodunk a munka fókuszában, a találkozások rendszerességében (1 vagy 2 hét) és az együttműködés fontos kereteiben."
       }
     }
   }


### PR DESCRIPTION
## Summary

- clarify the client situation about earlier goals no longer showing what comes next
- replace repetitive booking language with a direct first-session booking step
- explain what is clarified during the first 55-minute session
- define the continuation step as a mutual agreement on focus, one- or two-week frequency, and working boundaries
- mirror the semantic changes in English to keep both language versions consistent
- leave the About section and professional scope language unchanged

## Why

The previous wording used abstract references to “direction” and “pace,” which could be interpreted ambiguously. The revised copy explains the actual booking flow, the purpose of the first session, and how ongoing work is agreed together.

## User impact

Visitors receive clearer expectations about what happens before, during, and after the first session without changing the service or booking behavior.

## Validation

- parsed both updated locale files as JSON
- `npm run check`
- `npm run build`
- desktop visual QA at 1440 px
- mobile visual QA at 390 px
- confirmed all revised Hungarian copy renders with no horizontal overflow